### PR TITLE
Make Fv incremental + optimize feature trasformations

### DIFF
--- a/train_deploy_monitor_ML_in_snowflake.ipynb
+++ b/train_deploy_monitor_ML_in_snowflake.ipynb
@@ -1,7 +1,2344 @@
 {
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e79ae8e5-aec2-4276-9443-074c3a614142",
+   "metadata": {
+    "collapsed": false,
+    "name": "INTRO_MD"
+   },
+   "source": [
+    "# ❄️ End-to-end ML Demo ❄️\n",
+    "\n",
+    "In this worfklow we will work through the following elements of a typical tabular machine learning pipeline.\n",
+    "\n",
+    "### 1. Use Feature Store to track engineered features\n",
+    "* Store feature defintions in feature store for reproducible computation of ML features\n",
+    "      \n",
+    "### 2. Train two Models using the Snowflake ML APIs\n",
+    "* Baseline XGboost\n",
+    "* XGboost with optimal hyper-parameters identified via Snowflake ML distributed HPO methods\n",
+    "\n",
+    "### 3. Register both models in Snowflake model registry\n",
+    "* Explore model registry capabilities such as **metadata tracking, inference, and explainability**\n",
+    "* Compare model metrics on train/test set to identify any issues of model performance or overfitting\n",
+    "* Tag the best performing model version as 'default' version\n",
+    "### 4. Set up Model Monitor to track 1 year of predicted and actual loan repayments\n",
+    "* **Compute performance metrics** such a F1, Precision, Recall\n",
+    "* **Inspect model drift** (i.e. how much has the average predicted repayment rate changed day-to-day)\n",
+    "* **Compare models** side-by-side to understand which model should be used in production\n",
+    "* Identify and understand **data issues**\n",
+    "\n",
+    "### 5. Track data and model lineage throughout\n",
+    "* View and understand\n",
+    "  * The **origin of the data** used for computed features\n",
+    "  * The **data used** for model training\n",
+    "  * The **available model versions** being monitored"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a2512cb5-15ae-40b2-84c7-8a44a9979670",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": true,
+    "language": "python",
+    "name": "pip_installs"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting shap\n",
+      "  Downloading shap-0.47.0-cp39-cp39-macosx_11_0_arm64.whl.metadata (24 kB)\n",
+      "Requirement already satisfied: numpy in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (1.26.4)\n",
+      "Requirement already satisfied: scipy in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (1.13.0)\n",
+      "Requirement already satisfied: scikit-learn in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (1.5.2)\n",
+      "Requirement already satisfied: pandas in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (2.2.1)\n",
+      "Collecting tqdm>=4.27.0 (from shap)\n",
+      "  Using cached tqdm-4.67.1-py3-none-any.whl.metadata (57 kB)\n",
+      "Requirement already satisfied: packaging>20.9 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (24.0)\n",
+      "Collecting slicer==0.0.8 (from shap)\n",
+      "  Downloading slicer-0.0.8-py3-none-any.whl.metadata (4.0 kB)\n",
+      "Collecting numba>=0.54 (from shap)\n",
+      "  Downloading numba-0.60.0-cp39-cp39-macosx_11_0_arm64.whl.metadata (2.7 kB)\n",
+      "Requirement already satisfied: cloudpickle in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (2.2.1)\n",
+      "Requirement already satisfied: typing-extensions in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from shap) (4.11.0)\n",
+      "Collecting llvmlite<0.44,>=0.43.0dev0 (from numba>=0.54->shap)\n",
+      "  Downloading llvmlite-0.43.0-cp39-cp39-macosx_11_0_arm64.whl.metadata (4.8 kB)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from pandas->shap) (2.8.3+snowflake1)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from pandas->shap) (2023.3.post1)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from pandas->shap) (2023.3)\n",
+      "Requirement already satisfied: joblib>=1.2.0 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from scikit-learn->shap) (1.4.2)\n",
+      "Requirement already satisfied: threadpoolctl>=3.1.0 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from scikit-learn->shap) (3.5.0)\n",
+      "Requirement already satisfied: six>=1.5 in /opt/homebrew/anaconda3/envs/py39_env/lib/python3.9/site-packages (from python-dateutil>=2.8.2->pandas->shap) (1.16.0)\n",
+      "Downloading shap-0.47.0-cp39-cp39-macosx_11_0_arm64.whl (532 kB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m532.8/532.8 kB\u001b[0m \u001b[31m1.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hDownloading slicer-0.0.8-py3-none-any.whl (15 kB)\n",
+      "Downloading numba-0.60.0-cp39-cp39-macosx_11_0_arm64.whl (2.7 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.7/2.7 MB\u001b[0m \u001b[31m3.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hUsing cached tqdm-4.67.1-py3-none-any.whl (78 kB)\n",
+      "Downloading llvmlite-0.43.0-cp39-cp39-macosx_11_0_arm64.whl (28.8 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m28.8/28.8 MB\u001b[0m \u001b[31m22.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m00:01\u001b[0m00:01\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: tqdm, slicer, llvmlite, numba, shap\n",
+      "Successfully installed llvmlite-0.43.0 numba-0.60.0 shap-0.47.0 slicer-0.0.8 tqdm-4.67.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install shap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d78265b8-8baa-4136-a32a-32f3f620949d",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "set_version_num"
+   },
+   "outputs": [],
+   "source": [
+    "#Update this VERSION_NUM to version your features, models etc!\n",
+    "VERSION_NUM = '0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ce110000-1111-2222-3333-ffffff000000",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "imports_and_session",
+    "resultHeight": 84
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "SnowflakeLoginOptions() is in private preview since 0.2.0. Do not use it in production. \n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<snowflake.snowpark.session.Session at 0x375ac7ee0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import sklearn\n",
+    "import math\n",
+    "import pickle\n",
+    "import shap\n",
+    "from datetime import datetime\n",
+    "import streamlit as st\n",
+    "from xgboost import XGBClassifier\n",
+    "\n",
+    "# Snowpark ML\n",
+    "from snowflake.ml.registry import Registry\n",
+    "#from snowflake.ml.modeling.tune import get_tuner_context\n",
+    "#from snowflake.ml.modeling import tune\n",
+    "#from entities import search_algorithm\n",
+    "\n",
+    "#Snowflake feature store\n",
+    "from snowflake.ml.feature_store import FeatureStore, FeatureView, Entity, CreationMode\n",
+    "\n",
+    "# Snowpark session\n",
+    "from snowflake.snowpark import DataFrame\n",
+    "from snowflake.snowpark.functions import col, to_timestamp, min, max, month, dayofmonth, dayofweek, dayofyear, avg, median, date_add\n",
+    "from snowflake.snowpark.types import IntegerType\n",
+    "from snowflake.snowpark import Window\n",
+    "\n",
+    "#setup snowpark session\n",
+    "from snowflake.snowpark.context import get_active_session\n",
+    "from snowflake.snowpark.session import Session\n",
+    "from snowflake.ml.utils.connection_params import SnowflakeLoginOptions\n",
+    "session = Session.builder.configs(SnowflakeLoginOptions()).create()\n",
+    "session"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "f8900d1d-a1f2-419b-ae7e-b194f268d904",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "read_raw_data",
+    "resultHeight": 223
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading table data...\n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|\"LOAN_ID\"  |\"TS\"                     |\"LOAN_TYPE_NAME\"  |\"LOAN_PURPOSE_NAME\"  |\"APPLICANT_INCOME_000S\"  |\"LOAN_AMOUNT_000S\"  |\"COUNTY_NAME\"       |\"MORTGAGERESPONSE\"  |\n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|225846     |2024-08-09 23:51:21.600  |VA-guaranteed     |Refinancing          |NULL                     |160                 |Erie County         |1                   |\n",
+      "|298793     |2024-02-15 10:42:48.960  |VA-guaranteed     |Refinancing          |109.0                    |255                 |Erie County         |1                   |\n",
+      "|456295     |2024-05-17 06:29:48.480  |Conventional      |Home purchase        |283.0                    |392                 |Westchester County  |1                   |\n",
+      "|376334     |2024-06-21 11:55:14.880  |FHA-insured       |Refinancing          |43.0                     |173                 |Albany County       |0                   |\n",
+      "|216409     |2024-10-03 17:14:38.400  |Conventional      |Refinancing          |209.0                    |255                 |Kings County        |1                   |\n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    print(\"Reading table data...\")\n",
+    "    df = session.table(\"MORTGAGE_LENDING_DEMO_DATA\")\n",
+    "    df.show(5)\n",
+    "except:\n",
+    "    print(\"Table not found! Uploading data to snowflake table\")\n",
+    "    df_pandas = pd.read_csv(\"MORTGAGE_LENDING_DEMO_DATA.csv.zip\")\n",
+    "    session.write_pandas(df_pandas, \"MORTGAGE_LENDING_DEMO_DATA\", auto_create_table=True)\n",
+    "    df = session.table(\"MORTGAGE_LENDING_DEMO_DATA\")\n",
+    "    df.show(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60938b6f-bda7-4783-ae44-547bd34d98de",
+   "metadata": {
+    "collapsed": false,
+    "name": "md1"
+   },
+   "source": [
+    "## Observe Snowflake Snowpark table properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "369245"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a6654de7-6407-4ffe-a214-fd66078397ef",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "see_timespan",
+    "resultHeight": 111
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------------------------\n",
+      "|\"MIN(\"\"TS\"\")\"            |\"MAX(\"\"TS\"\")\"            |\n",
+      "-----------------------------------------------------\n",
+      "|2024-01-01 00:00:00.000  |2024-11-28 07:40:13.440  |\n",
+      "-----------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(min('TS'), max('TS')).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2024, 11, 28, 7, 40, 13, 440000)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Get current date and time\n",
+    "current_time = datetime.now()\n",
+    "# df_max_time = datetime.strptime(df.select(max(\"TS\")).collect()[0][0], \"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "df_max_time = datetime.strptime(str(df.select(max(\"TS\")).collect()[0][0]), \"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "df_max_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.timedelta(days=109, seconds=30598, microseconds=770251)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Find delta between latest existing timestamp and today's date\n",
+    "timedelta = current_time- df_max_time\n",
+    "timedelta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------------------------------\n",
+      "|\"MIN(DATEADD('DAY', 108, TO_TIMESTAMP(\"\"TS\"\")))\"  |\"MAX(DATEADD('DAY', 108, TO_TIMESTAMP(\"\"TS\"\")))\"  |\n",
+      "-------------------------------------------------------------------------------------------------------\n",
+      "|2024-04-18 00:00:00                               |2025-03-16 07:40:13.440000                        |\n",
+      "-------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.select(min(date_add(to_timestamp(\"TS\"), timedelta.days-1)), max(date_add(to_timestamp(\"TS\"), timedelta.days-1))).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b5a38cc-c479-4839-b0ae-9e5cb3e0facb",
+   "metadata": {
+    "codeCollapsed": false,
+    "language": "python",
+    "name": "find_timedelta"
+   },
+   "outputs": [],
+   "source": [
+    "#Get current date and time\n",
+    "current_time = datetime.now()\n",
+    "# df_max_time = datetime.strptime(df.select(max(\"TS\")).collect()[0][0], \"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "df_max_time = datetime.strptime(str(df.select(max(\"TS\")).collect()[0][0]), \"%Y-%m-%d %H:%M:%S.%f\")\n",
+    "\n",
+    "#Find delta between latest existing timestamp and today's date\n",
+    "timedelta = current_time- df_max_time\n",
+    "\n",
+    "#Update timestamps to represent last ~1 year from today's date\n",
+    "df.select(min(date_add(to_timestamp(\"TS\"), timedelta.days-1)), max(date_add(to_timestamp(\"TS\"), timedelta.days-1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8aa46c7d-519b-422c-8932-9b031fc6b4bd",
+   "metadata": {
+    "collapsed": false,
+    "name": "feat_eng_md"
+   },
+   "source": [
+    "## Feature Engineering with Snowpark APIs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b355c0c4-9dc6-4faf-86b7-24d8d559e453",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "define_features",
+    "resultHeight": 0
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|\"LOAN_ID\"  |\"TS\"                     |\"LOAN_TYPE_NAME\"  |\"LOAN_PURPOSE_NAME\"  |\"APPLICANT_INCOME_000S\"  |\"LOAN_AMOUNT_000S\"  |\"COUNTY_NAME\"  |\"MORTGAGERESPONSE\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"MEDIAN_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
+      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|329572     |2024-09-15 13:44:41.280  |Conventional      |Refinancing          |NULL                     |68                  |Kings County   |0                   |2025-01-01 13:44:41.280000  |1        |1              |3       |68000          |NULL      |NULL                 |111000.0                |NULL                |68000.000                     |\n",
+      "|266349     |2024-09-15 10:56:12.480  |Conventional      |Refinancing          |NULL                     |190                 |Ulster County  |1                   |2025-01-01 10:56:12.480000  |1        |1              |3       |190000         |NULL      |NULL                 |79000.0                 |NULL                |129000.000                    |\n",
+      "|220929     |2024-09-15 11:54:31.680  |Conventional      |Home purchase        |60.0                     |137                 |Albany County  |1                   |2025-01-01 11:54:31.680000  |1        |1              |3       |137000         |60000.0   |0.43795620437956206  |79000.0                 |0                   |131666.666                    |\n",
+      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Create a dict with keys for feature names and values containing transform code\n",
+    "\n",
+    "feature_eng_dict = dict()\n",
+    "\n",
+    "#Timstamp features\n",
+    "feature_eng_dict[\"TIMESTAMP\"] = date_add(to_timestamp(\"TS\"), timedelta.days-1)\n",
+    "feature_eng_dict[\"MONTH\"] = month(\"TIMESTAMP\")\n",
+    "feature_eng_dict[\"DAY_OF_YEAR\"] = dayofyear(\"TIMESTAMP\") \n",
+    "feature_eng_dict[\"DOTW\"] = dayofweek(\"TIMESTAMP\")\n",
+    "\n",
+    "# df= df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\n",
+    "\n",
+    "#Income and loan features\n",
+    "feature_eng_dict[\"LOAN_AMOUNT\"] = col(\"LOAN_AMOUNT_000s\")*1000\n",
+    "feature_eng_dict[\"INCOME\"] = col(\"APPLICANT_INCOME_000s\")*1000\n",
+    "feature_eng_dict[\"INCOME_LOAN_RATIO\"] = col(\"INCOME\")/col(\"LOAN_AMOUNT\")\n",
+    "\n",
+    "county_window_spec = Window.partition_by(\"COUNTY_NAME\")\n",
+    "feature_eng_dict[\"MEDIAN_COUNTY_INCOME\"] = median(\"INCOME\").over(county_window_spec)\n",
+    "feature_eng_dict[\"HIGH_INCOME_FLAG\"] = (col(\"INCOME\")>col(\"MEDIAN_COUNTY_INCOME\")).astype(IntegerType())\n",
+    "\n",
+    "day_window_spec = Window.order_by(\"DAY_OF_YEAR\").rows_between(-30,0)\n",
+    "feature_eng_dict[\"AVG_THIRTY_DAY_LOAN_AMOUNT\"] =  avg(\"LOAN_AMOUNT\").over(day_window_spec)\n",
+    "\n",
+    "df = df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\n",
+    "df.show(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_mortgage_features(df):\n",
+    "    # Step 1: Timestamp features (Per-row features)\n",
+    "    df = df.with_columns(\n",
+    "        [\"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\"],\n",
+    "        [\n",
+    "            date_add(to_timestamp(\"TS\"), timedelta.days-1),\n",
+    "            month(\"TIMESTAMP\"),\n",
+    "            dayofyear(\"TIMESTAMP\"),\n",
+    "            dayofweek(\"TIMESTAMP\")\n",
+    "        ]\n",
+    "    )\n",
+    "    \n",
+    "    # Step 2: Income and loan features (Per-row features)\n",
+    "    df = df.with_columns(\n",
+    "        [\"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\"],\n",
+    "        [\n",
+    "            col(\"LOAN_AMOUNT_000s\")*1000,\n",
+    "            col(\"APPLICANT_INCOME_000s\")*1000,\n",
+    "            col(\"INCOME\")/col(\"LOAN_AMOUNT\")\n",
+    "        ]\n",
+    "    )\n",
+    "    \n",
+    "    # Step 3: County-level income stats (Per-group features)\n",
+    "    county_income_df = df.group_by([\"COUNTY_NAME\"]).agg(\n",
+    "        median(\"INCOME\").alias(\"MEDIAN_COUNTY_INCOME\")\n",
+    "    )\n",
+    "    # Join back to the original dataframe\n",
+    "    df = df.join(county_income_df, \"COUNTY_NAME\")\n",
+    "    \n",
+    "    # Step 4: Add high income flag\n",
+    "    df = df.with_column(\n",
+    "        \"HIGH_INCOME_FLAG\", \n",
+    "        (col(\"INCOME\") > col(\"MEDIAN_COUNTY_INCOME\")).astype(IntegerType())\n",
+    "    )\n",
+    "    \n",
+    "    # Step 5: Time-based rolling average\n",
+    "    df = df.analytics.time_series_agg(\n",
+    "        aggs={\"LOAN_AMOUNT\": [\"AVG\"]},\n",
+    "        windows=[\"-30D\"],\n",
+    "        sliding_interval=\"1D\",\n",
+    "        time_col=\"TIMESTAMP\",\n",
+    "        group_by=[\"COUNTY_NAME\"] \n",
+    "    )\n",
+    "    df = df.rename(\"LOAN_AMOUNT_AVG_-30D\", \"AVG_THIRTY_DAY_LOAN_AMOUNT\")\n",
+    "\n",
+    "    # Step 6: Select only ID, timestamp, and engineered features\n",
+    "    feature_df = df.select(\n",
+    "        [\"LOAN_ID\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \n",
+    "         \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \n",
+    "         \"MEDIAN_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \n",
+    "         \"AVG_THIRTY_DAY_LOAN_AMOUNT\"]\n",
+    "    )\n",
+    "    \n",
+    "    return feature_df\n",
+    "\n",
+    "feature_df = create_mortgage_features(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feature_df.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|\"LOAN_ID\"  |\"TS\"                     |\"LOAN_TYPE_NAME\"    |\"LOAN_PURPOSE_NAME\"  |\"APPLICANT_INCOME_000S\"  |\"LOAN_AMOUNT_000S\"  |\"COUNTY_NAME\"       |\"MORTGAGERESPONSE\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"MEDIAN_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|329572     |2024-09-15 13:44:41.280  |Conventional        |Refinancing          |NULL                     |68                  |Kings County        |0                   |2025-01-01 13:44:41.280000  |1        |1              |3       |68000          |NULL      |NULL                 |111000.0                |NULL                |68000.000                     |\n",
+      "|266349     |2024-09-15 10:56:12.480  |Conventional        |Refinancing          |NULL                     |190                 |Ulster County       |1                   |2025-01-01 10:56:12.480000  |1        |1              |3       |190000         |NULL      |NULL                 |79000.0                 |NULL                |129000.000                    |\n",
+      "|220929     |2024-09-15 11:54:31.680  |Conventional        |Home purchase        |60.0                     |137                 |Albany County       |1                   |2025-01-01 11:54:31.680000  |1        |1              |3       |137000         |60000.0   |0.43795620437956206  |79000.0                 |0                   |131666.666                    |\n",
+      "|452183     |2024-09-15 20:57:33.120  |FHA-insured         |Refinancing          |66.0                     |303                 |Nassau County       |1                   |2025-01-01 20:57:33.120000  |1        |1              |3       |303000         |66000.0   |0.21782178217821782  |119000.0                |0                   |174500.000                    |\n",
+      "|201235     |2024-09-15 01:18:11.520  |Conventional        |Home purchase        |83.0                     |131                 |Ulster County       |1                   |2025-01-01 01:18:11.520000  |1        |1              |3       |131000         |83000.0   |0.6335877862595419   |79000.0                 |1                   |165800.000                    |\n",
+      "|428244     |2024-09-15 05:12:46.080  |Conventional        |Refinancing          |NULL                     |1158                |Kings County        |1                   |2025-01-01 05:12:46.080000  |1        |1              |3       |1158000        |NULL      |NULL                 |111000.0                |NULL                |331166.666                    |\n",
+      "|112782     |2024-09-15 21:04:01.920  |Conventional        |Refinancing          |55.0                     |90                  |Broome County       |1                   |2025-01-01 21:04:01.920000  |1        |1              |3       |90000          |55000.0   |0.6111111111111112   |59000.0                 |0                   |296714.285                    |\n",
+      "|136738     |2024-09-15 13:14:52.800  |Conventional        |Home purchase        |115.0                    |184                 |Bronx County        |1                   |2025-01-01 13:14:52.800000  |1        |1              |3       |184000         |115000.0  |0.625                |87000.0                 |1                   |282625.000                    |\n",
+      "|324015     |2024-09-15 03:09:38.880  |Conventional        |Home purchase        |121.0                    |100                 |Nassau County       |1                   |2025-01-01 03:09:38.880000  |1        |1              |3       |100000         |121000.0  |1.21                 |119000.0                |1                   |262333.333                    |\n",
+      "|132297     |2024-09-15 20:10:53.760  |Conventional        |Refinancing          |112.0                    |116                 |Suffolk County      |1                   |2025-01-01 20:10:53.760000  |1        |1              |3       |116000         |112000.0  |0.9655172413793104   |106000.0                |1                   |247700.000                    |\n",
+      "|109620     |2024-09-15 13:03:12.960  |FHA-insured         |Home purchase        |51.0                     |101                 |Monroe County       |1                   |2025-01-01 13:03:12.960000  |1        |1              |3       |101000         |51000.0   |0.504950495049505    |64000.0                 |0                   |234363.636                    |\n",
+      "|450041     |2024-09-15 03:31:40.800  |FHA-insured         |Home purchase        |NULL                     |33                  |Cattaraugus County  |1                   |2025-01-01 03:31:40.800000  |1        |1              |3       |33000          |NULL      |NULL                 |52000.0                 |NULL                |217583.333                    |\n",
+      "|299797     |2024-09-15 15:02:26.880  |Conventional        |Refinancing          |161.0                    |383                 |Suffolk County      |1                   |2025-01-01 15:02:26.880000  |1        |1              |3       |383000         |161000.0  |0.42036553524804177  |106000.0                |1                   |230307.692                    |\n",
+      "|407708     |2024-09-15 00:23:45.600  |Conventional        |Home improvement     |23.0                     |16                  |Nassau County       |0                   |2025-01-01 00:23:45.600000  |1        |1              |3       |16000          |23000.0   |1.4375               |119000.0                |0                   |215000.000                    |\n",
+      "|327330     |2024-09-15 14:36:31.680  |Conventional        |Home purchase        |NULL                     |850                 |New York County     |0                   |2025-01-01 14:36:31.680000  |1        |1              |3       |850000         |NULL      |NULL                 |228000.0                |NULL                |257333.333                    |\n",
+      "|220149     |2024-09-15 20:07:00.480  |Conventional        |Home improvement     |82.0                     |31                  |Erie County         |1                   |2025-01-01 20:07:00.480000  |1        |1              |3       |31000          |82000.0   |2.6451612903225805   |64000.0                 |1                   |243187.500                    |\n",
+      "|261060     |2024-09-15 09:35:51.360  |VA-guaranteed       |Home purchase        |77.0                     |148                 |Essex County        |1                   |2025-01-01 09:35:51.360000  |1        |1              |3       |148000         |77000.0   |0.5202702702702703   |68000.0                 |1                   |237588.235                    |\n",
+      "|237371     |2024-09-15 13:30:25.920  |Conventional        |Home purchase        |81.0                     |157                 |Erie County         |1                   |2025-01-01 13:30:25.920000  |1        |1              |3       |157000         |81000.0   |0.5159235668789809   |64000.0                 |1                   |233111.111                    |\n",
+      "|124223     |2024-09-15 11:24:43.200  |FSA/RHS-guaranteed  |Home purchase        |70.0                     |99                  |Wayne County        |1                   |2025-01-01 11:24:43.200000  |1        |1              |3       |99000          |70000.0   |0.7070707070707071   |59000.0                 |1                   |226052.631                    |\n",
+      "|425429     |2024-09-15 15:49:06.240  |Conventional        |Home purchase        |52.0                     |152                 |Nassau County       |1                   |2025-01-01 15:49:06.240000  |1        |1              |3       |152000         |52000.0   |0.34210526315789475  |119000.0                |0                   |222350.000                    |\n",
+      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.show(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "b6c4ead8-25ac-46cc-9bd9-17eac2f796d5",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "df_explain",
+    "resultHeight": 312
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---------DATAFRAME EXECUTION PLAN----------\n",
+      "Query List:\n",
+      "1.\n",
+      "SELECT  *  FROM MORTGAGE_LENDING_DEMO_DATA\n",
+      "Logical Execution Plan:\n",
+      "GlobalStats:\n",
+      "    partitionsTotal=1\n",
+      "    partitionsAssigned=1\n",
+      "    bytesAssigned=4618240\n",
+      "Operations:\n",
+      "1:0     ->Result  MORTGAGE_LENDING_DEMO_DATA.LOAN_ID, MORTGAGE_LENDING_DEMO_DATA.TS, MORTGAGE_LENDING_DEMO_DATA.LOAN_TYPE_NAME, MORTGAGE_LENDING_DEMO_DATA.LOAN_PURPOSE_NAME, MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S, MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S, MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, MORTGAGE_LENDING_DEMO_DATA.MORTGAGERESPONSE  \n",
+      "1:1          ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  LOAN_ID, TS, LOAN_TYPE_NAME, LOAN_PURPOSE_NAME, APPLICANT_INCOME_000S, LOAN_AMOUNT_000S, COUNTY_NAME, MORTGAGERESPONSE  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "\n",
+      "--------------------------------------------\n",
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df.explain())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72d7645e-e0ac-4539-b132-54ce53431402",
+   "metadata": {
+    "collapsed": false,
+    "name": "cell4"
+   },
+   "source": [
+    "## Create a Snowflake Feature Store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "abacdc71-9f2c-419f-8d50-3e8f89be367f",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "define_feature_store",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "fs = FeatureStore(\n",
+    "    session=session, \n",
+    "    database=session.get_current_database(), \n",
+    "    name=session.get_current_schema(), \n",
+    "    default_warehouse=session.get_current_warehouse(),\n",
+    "    creation_mode=CreationMode.CREATE_IF_NOT_EXIST\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "67480d6a-183f-4373-aaa8-d3ed8e80e11d",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "list_entities",
+    "resultHeight": 111
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<snowflake.snowpark.dataframe.DataFrame at 0x3200aa370>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fs.list_entities()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d915406f-e52d-4baf-9f6c-b9e0e8d53e6e",
+   "metadata": {
+    "collapsed": false,
+    "name": "FS_CONFIG_MD"
+   },
+   "source": [
+    "## Feature Store configuration\n",
+    "- create/register entities of interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "e91d6d39-7819-4825-8729-a3f19ca5cdf7",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "load_or_register_entity",
+    "resultHeight": 38
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Registered new entity\n"
+     ]
+    }
+   ],
+   "source": [
+    "#First try to retrieve an existing entity definition, if not define a new one and register\n",
+    "try:\n",
+    "    #retrieve existing entity\n",
+    "    loan_id_entity = fs.get_entity('LOAN_ENTITY') \n",
+    "    print('Retrieved existing entity')\n",
+    "except:\n",
+    "#define new entity\n",
+    "    loan_id_entity = Entity(\n",
+    "        name = \"LOAN_ENTITY\",\n",
+    "        join_keys = [\"LOAN_ID\"],\n",
+    "        desc = \"Features defined on a per loan level\")\n",
+    "    #register\n",
+    "    fs.register_entity(loan_id_entity)\n",
+    "    print(\"Registered new entity\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "2820463f-0ea7-43ea-a500-9b034011887d",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "create_feature_df",
+    "resultHeight": 217
+   },
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'show'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[32], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m#Create a dataframe with just the ID, timestamp, and engineered features. We will use this to define our feature view\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m#feature_df = df.select([\"LOAN_ID\"]+list(feature_eng_dict.keys()))\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[43mfeature_df\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m(\u001b[38;5;241m5\u001b[39m)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'show'"
+     ]
+    }
+   ],
+   "source": [
+    "#Create a dataframe with just the ID, timestamp, and engineered features. We will use this to define our feature view\n",
+    "#feature_df = df.select([\"LOAN_ID\"]+list(feature_eng_dict.keys()))\n",
+    "feature_df.show(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cf84fe3-4120-4092-b43d-8873da57d461",
+   "metadata": {
+    "collapsed": false,
+    "name": "FS_MD"
+   },
+   "source": [
+    "Here, the feature store references an existing table. \n",
+    "\n",
+    "We could also define the dataframe via the use of Snowpark APIs, and use that dataframe (or a function that returns a dataframe) as the feature view definition, below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b53364f-90c4-45b4-94ee-b2fde6f93475",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "feature_veiw_creation",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "#define and register feature view\n",
+    "loan_fv = FeatureView(\n",
+    "    name=\"Mortgage_Feature_View\",\n",
+    "    entities=[loan_id_entity],\n",
+    "    feature_df=feature_df,\n",
+    "    timestamp_col=\"TIMESTAMP\",\n",
+    "    refresh_freq=\"1 day\")\n",
+    "\n",
+    "#add feature level descriptions\n",
+    "\n",
+    "loan_fv = loan_fv.attach_feature_desc(\n",
+    "    {\n",
+    "        \"MONTH\": \"Month of loan\",\n",
+    "        \"DAY_OF_YEAR\": \"Day of calendar year of loan\",\n",
+    "        \"DOTW\": \"Day of the week of loan\",\n",
+    "        \"LOAN_AMOUNT\": \"Loan amount in $USD\",\n",
+    "        \"INCOME\": \"Household income in $USD\",\n",
+    "        \"INCOME_LOAN_RATIO\": \"Ratio of LOAN_AMOUNT/INCOME\",\n",
+    "        \"MEDIAN_COUNTY_INCOME\": \"Median household income aggregated at county level\",\n",
+    "        \"HIGH_INCOME_FLAG\": \"Binary flag to indicate whether household income is higher than MEDIAN_COUNTY_INCOME\",\n",
+    "        \"AVG_THIRTY_DAY_LOAN_AMOUNT\": \"Rolling 30 day average of LOAN_AMOUNT\"\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "loan_fv = fs.register_feature_view(loan_fv, version=VERSION_NUM, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18c3225b-b936-4aa7-81f2-27bbaeee1c0f",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "show_feature_views",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "fs.list_feature_views()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f7a1aae-0bd2-4aad-b9ed-3347fc56b6ea",
+   "metadata": {
+    "codeCollapsed": false,
+    "language": "python",
+    "name": "create_feature_store_link"
+   },
+   "outputs": [],
+   "source": [
+    "#Create link to feature store UI to inspect newly created feature view!\n",
+    "\n",
+    "org_name = session.sql('SELECT CURRENT_ORGANIZATION_NAME()').collect()[0][0]\n",
+    "account_name = session.sql('SELECT CURRENT_ACCOUNT_NAME()').collect()[0][0]\n",
+    "db_name = session.sql('SELECT CURRENT_DATABASE()').collect()[0][0]\n",
+    "schema_name = session.sql('SELECT CURRENT_SCHEMA()').collect()[0][0]\n",
+    "\n",
+    "st.write(f'https://app.snowflake.com/{org_name}/{account_name}/#/features/database/{db_name}/store/{schema_name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e96ff67f-bb04-40cb-8c14-11b5ebb2917d",
+   "metadata": {
+    "collapsed": false,
+    "name": "FV_MD"
+   },
+   "source": [
+    "## Retrieve a Dataset from the featureview\n",
+    "\n",
+    "Snowflake Datasets are immutable, file-based objects that exist within your Snowpark session. \n",
+    "\n",
+    "They can be written to persistent Snowflake objects as needed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "535efc80-e4fc-41c5-98eb-5b5450bcf199",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "generate_dataset",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "ds = fs.generate_dataset(\n",
+    "    name=f\"MORTGAGE_DATASET_EXTENDED_FEATURES_{VERSION_NUM}\",\n",
+    "    spine_df=df.select(\"LOAN_ID\", \"TIMESTAMP\", \"LOAN_PURPOSE_NAME\",\"MORTGAGERESPONSE\"), #only need the features used to fetch rest of feature view\n",
+    "    features=[loan_fv],\n",
+    "    spine_timestamp_col=\"TIMESTAMP\",\n",
+    "    spine_label_cols=[\"MORTGAGERESPONSE\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecdaa537-3fb9-476c-9153-3236edfdfcb3",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "convert_dataset_to_snowpark_and_pandas",
+    "resultHeight": 239
+   },
+   "outputs": [],
+   "source": [
+    "ds_sp = ds.read.to_snowpark_dataframe()\n",
+    "ds_sp.show(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5e17036-7a69-4915-b025-49c900aeb46b",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "one_hot_encoding",
+    "resultHeight": 360
+   },
+   "outputs": [],
+   "source": [
+    "import snowflake.ml.modeling.preprocessing as snowml\n",
+    "from snowflake.snowpark.types import StringType\n",
+    "\n",
+    "OHE_COLS = ds_sp.select([col.name for col in ds_sp.schema if col.datatype ==StringType()]).columns\n",
+    "OHE_POST_COLS = [i+\"_OHE\" for i in OHE_COLS]\n",
+    "\n",
+    "\n",
+    "# Encode categoricals to numeric columns\n",
+    "snowml_ohe = snowml.OneHotEncoder(input_cols=OHE_COLS, output_cols = OHE_COLS, drop_input_cols=True)\n",
+    "ds_sp_ohe = snowml_ohe.fit(ds_sp).transform(ds_sp)\n",
+    "\n",
+    "#Rename columns to avoid double nested quotes and white space chars\n",
+    "rename_dict = {}\n",
+    "for i in ds_sp_ohe.columns:\n",
+    "    if '\"' in i:\n",
+    "        rename_dict[i] = i.replace('\"','').replace(' ', '_')\n",
+    "\n",
+    "ds_sp_ohe = ds_sp_ohe.rename(rename_dict)\n",
+    "ds_sp_ohe.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d834f6f3-ce15-405e-8fec-1d1bb5c224a6",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "train_test_split",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "train, test = ds_sp_ohe.random_split(weights=[0.70, 0.30], seed=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8ff103e-5314-4e95-87ba-d784b1102f36",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "fill_na",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "train = train.fillna(0)\n",
+    "test = test.fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c917df7f-e277-4fbb-abf5-1a4433367e3b",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "convert_data_to_pandas"
+   },
+   "outputs": [],
+   "source": [
+    "train_pd = train.to_pandas()\n",
+    "test_pd = test.to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4a295d0-f4a5-48e1-8eab-4d3f67ba5942",
+   "metadata": {
+    "collapsed": false,
+    "name": "cell11"
+   },
+   "source": [
+    "## Configure model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e4b5fba-b7a8-47ff-aaf6-076b9e78dcaf",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "define_model",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "#Define model config\n",
+    "xgb_base = XGBClassifier(\n",
+    "    max_depth=50,\n",
+    "    n_estimators=3,\n",
+    "    learning_rate = 0.75,\n",
+    "    booster = 'gbtree')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ed4b51d-e83c-4e1e-a9df-3b504e20abf0",
+   "metadata": {
+    "collapsed": false,
+    "name": "cell12"
+   },
+   "source": [
+    "## Fit the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644f3295-2496-4fd0-ae95-922a78c5b944",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "train_base_model",
+    "resultHeight": 1759
+   },
+   "outputs": [],
+   "source": [
+    "#Split train data into X, y\n",
+    "X_train_pd = train_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1) #remove\n",
+    "y_train_pd = train_pd.MORTGAGERESPONSE\n",
+    "\n",
+    "#train model\n",
+    "xgb_base.fit(X_train_pd,y_train_pd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4ed8ace-06a4-4e74-a53c-e9a681f602bf",
+   "metadata": {
+    "collapsed": false,
+    "name": "cell10"
+   },
+   "source": [
+    "Measure baseline performance of our first version\n",
+    "\n",
+    "Note that here, we simply use OSS methods from scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c5ac861-fcf9-47b2-9c11-ec44ee2367e4",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "compute_predictions_and_perf_metrics"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import f1_score, precision_score, recall_score\n",
+    "train_preds_base = xgb_base.predict(X_train_pd) #update this line with correct ata\n",
+    "\n",
+    "f1_base_train = round(f1_score(y_train_pd, train_preds_base),4)\n",
+    "precision_base_train = round(precision_score(y_train_pd, train_preds_base),4)\n",
+    "recall_base_train = round(recall_score(y_train_pd, train_preds_base),4)\n",
+    "\n",
+    "print(f'F1: {f1_base_train} \\nPrecision {precision_base_train} \\nRecall: {recall_base_train}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93777778-d2ba-42d5-88c4-a90ba18c5006",
+   "metadata": {
+    "collapsed": false,
+    "name": "model_regisry_md",
+    "resultHeight": 74
+   },
+   "source": [
+    "# Model Registry\n",
+    "\n",
+    "- Log models with important metadata\n",
+    "- Manage model lifecycles\n",
+    "- Serve models from Snowflake runtimes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21678e59-deaf-4c2b-b01e-1c59fe31b10a",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "define_model_registry",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "#Create a snowflake model registry object \n",
+    "from snowflake.ml.registry import Registry\n",
+    "from snowflake.ml._internal.utils import identifier\n",
+    "from snowflake.ml.model import model_signature\n",
+    "\n",
+    "db = identifier._get_unescaped_name(session.get_current_database())\n",
+    "schema = identifier._get_unescaped_name(session.get_current_schema())\n",
+    "\n",
+    "\n",
+    "# Define model name\n",
+    "model_name = f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\"\n",
+    "\n",
+    "# Create a registry to log the model to\n",
+    "model_registry = Registry(session=session, \n",
+    "                          database_name=db, \n",
+    "                          schema_name=schema,\n",
+    "                          options={\"enable_monitoring\": True})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be41c3ac-49f0-4fd9-a557-9d8eb633f602",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "register_model_version",
+    "resultHeight": 229
+   },
+   "outputs": [],
+   "source": [
+    "#Deploy the base model to the model registry\n",
+    "base_version_name = 'XGB_BASE'\n",
+    "\n",
+    "try:\n",
+    "    mv_base = model_registry.get_model(model_name).version(base_version_name)\n",
+    "    print(\"Found existing model version!\")\n",
+    "except:\n",
+    "    print(\"Logging new model version...\")\n",
+    "    mv_base = model_registry.log_model(\n",
+    "        model_name=model_name,\n",
+    "        model=xgb_base, \n",
+    "        version_name=base_version_name,\n",
+    "        sample_input_data = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).limit(100), #using snowpark df to maintain lineage\n",
+    "        comment = \"\"\"ML model for predicting loan approval likelihood.\n",
+    "                    This model was trained using  xgboost classifier.\n",
+    "                    Hyperparameters used were:a\n",
+    "                    max_depth=50, n_estimators=3, learning_rate = 0.75, algorithm = gbtree.\n",
+    "                    \"\"\",\n",
+    "    )\n",
+    "    mv_base.set_metric(metric_name=\"Train_F1_Score\", value=f1_base_train)\n",
+    "    mv_base.set_metric(metric_name=\"Train_Precision_Score\", value=precision_base_train)\n",
+    "    mv_base.set_metric(metric_name=\"Train_Recall_score\", value=recall_base_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68e2ddab-b02a-4e05-8121-4e97e49e0eea",
+   "metadata": {
+    "codeCollapsed": false,
+    "language": "python",
+    "name": "cell16"
+   },
+   "outputs": [],
+   "source": [
+    "session.sql(\"CREATE OR REPLACE TAG PROD\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e0054df-0cd9-4e81-98b8-6564be86b4b9",
+   "metadata": {
+    "codeCollapsed": false,
+    "language": "python",
+    "name": "create_PROD_tag"
+   },
+   "outputs": [],
+   "source": [
+    "#Create tag for PROD model and apply \n",
+    "session.sql(\"CREATE OR REPLACE TAG PROD\")\n",
+    "m = model_registry.get_model(model_name)\n",
+    "m.set_tag(\"PROD\", base_version_name)\n",
+    "m.comment = \"Loan approval prediction models\" #set model level comment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac4e294e-929d-4399-b2bb-d5d2d1dd043e",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "show_models",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "model_registry.show_models()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3dfb281-9751-48a1-a76e-43ffffd9d099",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "show_model_versions",
+    "resultHeight": 146
+   },
+   "outputs": [],
+   "source": [
+    "model_registry.get_model(model_name).show_versions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb1af8a1-7a92-455e-b9a1-8f2c699dfdeb",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "print_model_version_and_metrics",
+    "resultHeight": 239
+   },
+   "outputs": [],
+   "source": [
+    "print(mv_base)\n",
+    "print(mv_base.show_metrics())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ecdf05c-b3b5-4755-bdff-fd187ef07f58",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "show_model_functions",
+    "resultHeight": 2133
+   },
+   "outputs": [],
+   "source": [
+    "mv_base.show_functions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf495261-a8a7-46be-b9c8-3f099268d154",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "predict_from_registry",
+    "resultHeight": 351
+   },
+   "outputs": [],
+   "source": [
+    "reg_preds = mv_base.run(test, function_name = \"predict\")\n",
+    "reg_preds.show(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efae2c0c-80d4-412c-8322-0e4ecceeb6f9",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "cell17"
+   },
+   "outputs": [],
+   "source": [
+    "reg_preds = reg_preds.rename(col('\"output_feature_0\"'), \"MORTGAGE_PREDICTION\")\n",
+    "reg_preds.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ef61447-10e7-4a38-a429-3da3facf9ce7",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "compute_test_metrics"
+   },
+   "outputs": [],
+   "source": [
+    "#ds_sp_ohe = ds_sp_ohe.rename(col('\"LOAN_PURPOSE_NAME_Home improvement\"'), \"LOAN_PURPOSE_NAME_Home_improvement\")\n",
+    "\n",
+    "preds_pd = reg_preds.select([\"MORTGAGERESPONSE\", \"MORTGAGE_PREDICTION\"]).to_pandas()\n",
+    "f1_base_test = round(f1_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\n",
+    "precision_base_test = round(precision_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\n",
+    "recall_base_test = round(recall_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\n",
+    "\n",
+    "#log metrics to model registry model\n",
+    "mv_base.set_metric(metric_name=\"Test_F1_Score\", value=f1_base_test)\n",
+    "mv_base.set_metric(metric_name=\"Test_Precision_Score\", value=precision_base_test)\n",
+    "mv_base.set_metric(metric_name=\"Test_Recall_score\", value=recall_base_test)\n",
+    "\n",
+    "print(f'F1: {f1_base_test} \\nPrecision {precision_base_test} \\nRecall: {recall_base_test}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b477885-35ce-486d-9e86-7d0cc9d48454",
+   "metadata": {
+    "collapsed": false,
+    "name": "HPO_MD"
+   },
+   "source": [
+    "# Oh no! Our model's performance seems to have dropped off significantly from training to our test set. \n",
+    "## This is evidence that our model is overfit - can we fix this with Distributed Hyperparameter Optimization??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c47e068d-7e1d-4c74-8289-d03ea8ab3c7e",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "setup_x_and_y"
+   },
+   "outputs": [],
+   "source": [
+    "X_train = train.drop(\"MORTGAGERESPONSE\", \"TIMESTAMP\", \"LOAN_ID\")\n",
+    "y_train = train.select(\"MORTGAGERESPONSE\")\n",
+    "X_test = test.drop(\"MORTGAGERESPONSE\",\"TIMESTAMP\", \"LOAN_ID\")\n",
+    "y_test = test.select(\"MORTGAGERESPONSE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fff76e05-38f5-47cf-ab5d-9eefed09bd71",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "define_HPO_config"
+   },
+   "outputs": [],
+   "source": [
+    "from snowflake.ml.data import DataConnector\n",
+    "from snowflake.ml.modeling.tune import get_tuner_context\n",
+    "from snowflake.ml.modeling import tune\n",
+    "from entities import search_algorithm\n",
+    "\n",
+    "#Define dataset map\n",
+    "dataset_map = {\n",
+    "    \"x_train\": DataConnector.from_dataframe(X_train),\n",
+    "    \"y_train\": DataConnector.from_dataframe(y_train),\n",
+    "    \"x_test\": DataConnector.from_dataframe(X_test),\n",
+    "    \"y_test\": DataConnector.from_dataframe(y_test)\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "# Define a training function, with any models you choose within it.\n",
+    "def train_func():\n",
+    "    # A context object provided by HPO API to expose data for the current HPO trial\n",
+    "    tuner_context = get_tuner_context()\n",
+    "    config = tuner_context.get_hyper_params()\n",
+    "    dm = tuner_context.get_dataset_map()\n",
+    "\n",
+    "    model = XGBClassifier(**config, random_state=42)\n",
+    "    model.fit(dm[\"x_train\"].to_pandas().sort_index(), dm[\"y_train\"].to_pandas().sort_index())\n",
+    "    f1_metric = f1_score(\n",
+    "        dm[\"y_train\"].to_pandas().sort_index(), model.predict(dm[\"x_train\"].to_pandas().sort_index())\n",
+    "    )\n",
+    "    tuner_context.report(metrics={\"f1_score\": f1_metric}, model=model)\n",
+    "\n",
+    "tuner = tune.Tuner(\n",
+    "    train_func=train_func,\n",
+    "    search_space={\n",
+    "        \"max_depth\": tune.randint(1, 20),\n",
+    "        \"learning_rate\": tune.uniform(0.01, 0.1),\n",
+    "        \"n_estimators\": tune.randint(50, 100),\n",
+    "    },\n",
+    "    tuner_config=tune.TunerConfig(\n",
+    "        metric=\"f1_score\",\n",
+    "        mode=\"max\",\n",
+    "        search_alg=search_algorithm.RandomSearch(random_state=101),\n",
+    "        num_trials=8, #run 8 trial runs\n",
+    "        max_concurrent_trials=4, #use 4 gpus concurrently\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14b88e99-9d2a-44cd-81f9-d53fd1321daf",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": true,
+    "language": "python",
+    "name": "run_hpo"
+   },
+   "outputs": [],
+   "source": [
+    "tuner_results = tuner.run(dataset_map=dataset_map)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ee37c42-3de7-476a-b7c0-d56952dac385",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "inspect_hpo_params"
+   },
+   "outputs": [],
+   "source": [
+    "tuned_model = tuner_results.best_model\n",
+    "tuned_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94b4a6c2-674e-4d02-afdb-8ebf10cffdc4",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "compute_hpo_train_predictions_and_metrics"
+   },
+   "outputs": [],
+   "source": [
+    "#Generate predictions\n",
+    "xgb_opt_preds = tuned_model.predict(train_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1))\n",
+    "\n",
+    "#Generate performance metrics\n",
+    "f1_opt_train = round(f1_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\n",
+    "precision_opt_train = round(precision_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\n",
+    "recall_opt_train = round(recall_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\n",
+    "\n",
+    "print(f'Train Results: \\nF1: {f1_opt_train} \\nPrecision {precision_opt_train} \\nRecall: {recall_opt_train}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dee80c48-d521-4b77-8841-54ba35ecd4b6",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "compute_hpo_test_predictions_and_metrics"
+   },
+   "outputs": [],
+   "source": [
+    "#Generate test predictions\n",
+    "xgb_opt_preds_test = tuned_model.predict(test_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1))\n",
+    "\n",
+    "#Generate performance metrics on test data\n",
+    "f1_opt_test = round(f1_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\n",
+    "precision_opt_test = round(precision_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\n",
+    "recall_opt_test = round(recall_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\n",
+    "\n",
+    "print(f'Test Results: \\nF1: {f1_opt_test} \\nPrecision {precision_opt_test} \\nRecall: {recall_opt_test}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89a1a670-52e3-4d77-ac3a-db830e22fdcf",
+   "metadata": {
+    "collapsed": false,
+    "name": "HPO_performance_reaction"
+   },
+   "source": [
+    "# Here we see the HPO model has a more modest train accuracy than our base model - but the peformance doesn't drop off during testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d501cf7d-4965-4b9f-8b16-edab897d0e18",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "log_hpo_model"
+   },
+   "outputs": [],
+   "source": [
+    "#Log the optimized model to the model registry\n",
+    "optimized_version_name = 'XGB_Optimized'\n",
+    "\n",
+    "try:\n",
+    "    mv_opt = model_registry.get_model(model_name).version(optimized_version_name)\n",
+    "    print(\"Found existing model version!\")\n",
+    "except:\n",
+    "    print(\"Logging new model version...\")\n",
+    "    mv_opt = model_registry.log_model(\n",
+    "        model_name=model_name,\n",
+    "        model=tuned_model, \n",
+    "        version_name=optimized_version_name,\n",
+    "        sample_input_data = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).limit(100),\n",
+    "        comment = \"snow ml model built off feature store using HPO model\",\n",
+    "    )\n",
+    "    mv_opt.set_metric(metric_name=\"Train_F1_Score\", value=f1_opt_train)\n",
+    "    mv_opt.set_metric(metric_name=\"Train_Precision_Score\", value=precision_opt_train)\n",
+    "    mv_opt.set_metric(metric_name=\"Train_Recall_score\", value=recall_opt_train)\n",
+    "\n",
+    "    mv_opt.set_metric(metric_name=\"Test_F1_Score\", value=f1_opt_test)\n",
+    "    mv_opt.set_metric(metric_name=\"Test_Precision_Score\", value=precision_opt_test)\n",
+    "    mv_opt.set_metric(metric_name=\"Test_Recall_score\", value=recall_opt_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c028b9-b590-45b4-9884-35ee206bca0d",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "inspect_current_default_version"
+   },
+   "outputs": [],
+   "source": [
+    "#Here we see the BASE version is our default version\n",
+    "model_registry.get_model(model_name).default"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04ac97a9-7af4-4331-bb0d-cf6ecc4a77f6",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "promote_optimized_version_to_default"
+   },
+   "outputs": [],
+   "source": [
+    "#Now we'll set the optimized model to be the default model version going forward\n",
+    "model_registry.get_model(model_name).default = optimized_version_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c04efcee-27e6-4423-b669-849bec7cc8fb",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "see_updated_model_versions"
+   },
+   "outputs": [],
+   "source": [
+    "#Now we see our optimized version we have now recently promoted to our DEFAULT model version\n",
+    "model_registry.get_model(model_name).default"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cc92f7f-5f02-4cc5-82d0-758f65f2d485",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "update_model_tags"
+   },
+   "outputs": [],
+   "source": [
+    "#we'll now update the PROD tagged model to be the optimized model version rather than our overfit base version\n",
+    "m.unset_tag(\"PROD\")\n",
+    "m.set_tag(\"PROD\", optimized_version_name)\n",
+    "m.show_tags()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05fff15e-5f49-4d4f-a02a-93e8f3114b11",
+   "metadata": {
+    "collapsed": false,
+    "name": "explainability_MD"
+   },
+   "source": [
+    "## Now that we've deployed some model versions and tested inference... \n",
+    "# Let's explain our models!\n",
+    "- ### Snowflake offers built in explainability capabilities on top of models logged to the model registry\n",
+    "- ### In the below section we'll generate shapley values using these built in functions to understand how input features impact our model's behavior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "914f5cd6-d254-42d4-a0be-9848c9d09d4a",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "compute_shap_vals",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "#create a sample of 1000 records\n",
+    "test_pd_sample=test_pd.rename(columns=rename_dict).sample(n=1000, random_state = 100).reset_index(drop=True)\n",
+    "\n",
+    "#Compute shapley values for each model\n",
+    "base_shap_pd = mv_base.run(test_pd_sample, function_name=\"explain\")\n",
+    "opt_shap_pd = mv_opt.run(test_pd_sample, function_name=\"explain\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f74e0dcc-a850-474a-b475-f05a77619731",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "base_shap_summary_plot",
+    "resultHeight": 571
+   },
+   "outputs": [],
+   "source": [
+    "import shap \n",
+    "\n",
+    "shap.summary_plot(np.array(base_shap_pd.astype(float)), \n",
+    "                  test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1), \n",
+    "                  feature_names = test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1).columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67469a84-3d44-49e4-8d6e-5cd8a6e8a633",
+   "metadata": {
+    "language": "python",
+    "name": "cell8"
+   },
+   "outputs": [],
+   "source": [
+    "shap.summary_plot(np.array(opt_shap_pd.astype(float)), \n",
+    "                  test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1), \n",
+    "                  feature_names = test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1).columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3a0d4c3-750c-4ae0-9812-85b677db6986",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "create_all_shap_dfs"
+   },
+   "outputs": [],
+   "source": [
+    "#Merge shap vals and actual vals together for easier plotting below\n",
+    "all_shap_base = test_pd_sample.merge(base_shap_pd, right_index=True, left_index=True, how='outer')\n",
+    "all_shap_opt = test_pd_sample.merge(opt_shap_pd, right_index=True, left_index=True, how='outer')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "938441fd-9ae3-4f97-9a54-b7e4c74738ac",
+   "metadata": {
+    "language": "python",
+    "name": "plot_income_explanation"
+   },
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "#filter data down to strip outliers\n",
+    "asb_filtered = all_shap_base[(all_shap_base.INCOME>0) & (all_shap_base.INCOME<250000)]\n",
+    "aso_filtered = all_shap_opt[(all_shap_opt.INCOME>0) & (all_shap_opt.INCOME<250000)]\n",
+    "\n",
+    "# Set up the figure\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 6))\n",
+    "fig.suptitle(\"INCOME EXPLANATION\")\n",
+    "# Plot side-by-side boxplots\n",
+    "sns.scatterplot(data = asb_filtered, x ='INCOME', y = 'INCOME_explanation', ax=axes[0])\n",
+    "sns.regplot(data = asb_filtered, x =\"INCOME\", y = 'INCOME_explanation', scatter=False, color='red', line_kws={\"lw\":2},ci =100, lowess=False, ax =axes[0])\n",
+    "\n",
+    "axes[0].set_title('Base Model')\n",
+    "sns.scatterplot(data = aso_filtered, x ='INCOME', y = 'INCOME_explanation',color = \"orange\", ax = axes[1])\n",
+    "sns.regplot(data = aso_filtered, x =\"INCOME\", y = 'INCOME_explanation', scatter=False, color='blue', line_kws={\"lw\":2},ci =100, lowess=False, ax =axes[1])\n",
+    "axes[1].set_title('Opt Model')\n",
+    "\n",
+    "# Customize and show the plot\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"Income\")\n",
+    "    ax.set_ylabel(\"Influence\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2298b1f8-0495-42e1-b668-0dcd03d8bb7c",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "plot_loan_amount_explanation"
+   },
+   "outputs": [],
+   "source": [
+    "#filter data down to strip outliers\n",
+    "asb_filtered = all_shap_base[all_shap_base.LOAN_AMOUNT<2000000]\n",
+    "aso_filtered = all_shap_opt[all_shap_opt.LOAN_AMOUNT<2000000]\n",
+    "\n",
+    "\n",
+    "# Set up the figure\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 6))\n",
+    "fig.suptitle(\"LOAN_AMOUNT EXPLANATION\")\n",
+    "# Plot side-by-side boxplots\n",
+    "sns.scatterplot(data = asb_filtered, x ='LOAN_AMOUNT', y = 'LOAN_AMOUNT_explanation', ax=axes[0])\n",
+    "sns.regplot(data = asb_filtered, x =\"LOAN_AMOUNT\", y = 'LOAN_AMOUNT_explanation', scatter=False, color='red', line_kws={\"lw\":2},ci =100, lowess=True, ax =axes[0])\n",
+    "axes[0].set_title('Base Model')\n",
+    "\n",
+    "sns.scatterplot(data = aso_filtered, x ='LOAN_AMOUNT', y = 'LOAN_AMOUNT_explanation',color = \"orange\", ax = axes[1])\n",
+    "sns.regplot(data = aso_filtered, x =\"LOAN_AMOUNT\", y = 'LOAN_AMOUNT_explanation', scatter=False, color='blue', line_kws={\"lw\":2},ci =100, lowess=True, ax =axes[1])\n",
+    "axes[1].set_title('Opt Model')\n",
+    "\n",
+    "# Customize and show the plot\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"LOAN_AMOUNT\")\n",
+    "    ax.set_ylabel(\"Influence\")\n",
+    "    # ax.set_xlim((0,10000))\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14a03aa9-1f1a-4a4e-809e-b22e438d72aa",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "plot_home_purchase_explanation",
+    "resultHeight": 851
+   },
+   "outputs": [],
+   "source": [
+    "# Set up the figure\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 6))\n",
+    "fig.suptitle(\"HOME PURCHASE LOAN EXPLANATION\")\n",
+    "# Plot side-by-side boxplots\n",
+    "sns.boxplot(data = all_shap_base, x ='LOAN_PURPOSE_NAME_HOME_PURCHASE', y = 'LOAN_PURPOSE_NAME_HOME_PURCHASE_explanation',\n",
+    "            hue='LOAN_PURPOSE_NAME_HOME_PURCHASE', width=0.8, ax=axes[0])\n",
+    "axes[0].set_title('Base Model')\n",
+    "sns.boxplot(data = all_shap_opt, x ='LOAN_PURPOSE_NAME_HOME_PURCHASE', y = 'LOAN_PURPOSE_NAME_HOME_PURCHASE_explanation',\n",
+    "            hue='LOAN_PURPOSE_NAME_HOME_PURCHASE', width=0.4, ax = axes[1])\n",
+    "axes[1].set_title('Opt Model')\n",
+    "\n",
+    "# Customize and show the plot\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"Home PURCHASE Loan (1 = True)\")\n",
+    "    ax.set_ylabel(\"Influence\")\n",
+    "    ax.legend(loc='upper right')\n",
+    "\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66ea7aad-4e48-4666-a48c-ddc39331cb1f",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "plot_home_imrprovement_explanation"
+   },
+   "outputs": [],
+   "source": [
+    "# Set up the figure\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 6))\n",
+    "fig.suptitle(\"HOME IMPROVEMENT LOAN EXPLANATION\")\n",
+    "# Plot side-by-side boxplots\n",
+    "sns.boxplot(data = all_shap_base, x ='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', y = 'LOAN_PURPOSE_NAME_HOME_IMPROVEMENT_explanation',\n",
+    "            hue='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', width=0.8, ax=axes[0])\n",
+    "axes[0].set_title('Base Model')\n",
+    "sns.boxplot(data = all_shap_opt, x ='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', y = 'LOAN_PURPOSE_NAME_HOME_IMPROVEMENT_explanation',\n",
+    "            hue='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', width=0.4, ax = axes[1])\n",
+    "axes[1].set_title('Opt Model')\n",
+    "\n",
+    "# Customize and show the plot\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"Home Improvement Loan (1 = True)\")\n",
+    "    ax.set_ylabel(\"Influence\")\n",
+    "    ax.legend(loc='upper right')\n",
+    "\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df7a9ccc-e785-4a82-b9e9-97fd44d5acf2",
+   "metadata": {
+    "collapsed": false,
+    "name": "Monitoring_section",
+    "resultHeight": 74
+   },
+   "source": [
+    "# Model Monitoring setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0751bdd-6c24-4c65-9247-aa90ebc1d376",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "create_table_from_test_data",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "train.write.save_as_table(f\"DEMO_MORTGAGE_LENDING_TRAIN_{VERSION_NUM}\", mode=\"overwrite\")\n",
+    "test.write.save_as_table(f\"DEMO_MORTGAGE_LENDING_TEST_{VERSION_NUM}\", mode=\"overwrite\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aabdf2be-87f8-4556-aa42-22e4a70515e1",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "create_stage",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "session.sql(\"CREATE stage IF NOT EXISTS ML_STAGE\").collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21b2c090-5cc8-4847-982a-fb9b5e427616",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "define_sproc",
+    "resultHeight": 495
+   },
+   "outputs": [],
+   "source": [
+    "from snowflake import snowpark\n",
+    "from snowflake.ml.registry import Registry\n",
+    "import joblib\n",
+    "import os\n",
+    "import logging\n",
+    "from snowflake.ml.modeling.pipeline import Pipeline\n",
+    "import snowflake.ml.modeling.preprocessing as pp\n",
+    "from snowflake.snowpark.types import StringType, IntegerType\n",
+    "import snowflake.snowpark.functions as F\n",
+    "\n",
+    "\n",
+    "def demo_inference_sproc(session: snowpark.Session, table_name: str, modelname: str, modelversion: str) -> str:\n",
+    "    \n",
+    "    database=session.get_current_database()\n",
+    "    schema=session.get_current_schema()\n",
+    "    reg = Registry(session=session)\n",
+    "    m = reg.get_model(model_name)  # Fetch the model using the registry\n",
+    "    mv = m.version(modelversion)\n",
+    "    \n",
+    "    input_table_name=table_name\n",
+    "    pred_col = f'{modelversion}_PREDICTION'\n",
+    "\n",
+    "    # Read the input table to a dataframe\n",
+    "    df = session.table(input_table_name)\n",
+    "    results = mv.run(df, function_name=\"predict\").select(\"LOAN_ID\",'\"output_feature_0\"').withColumnRenamed('\"output_feature_0\"', pred_col)\n",
+    "    # 'results' is the output DataFrame with predictions\n",
+    "\n",
+    "    final = df.join(results, on=\"LOAN_ID\", how=\"full\")\n",
+    "    # Write results back to Snowflake table\n",
+    "    final.write.save_as_table(table_name, mode='overwrite',enable_schema_evolution=True)\n",
+    "\n",
+    "    return \"Success\"\n",
+    "\n",
+    "# Register the stored procedure\n",
+    "session.sproc.register(\n",
+    "    func=demo_inference_sproc,\n",
+    "    name=\"model_inference_sproc\",\n",
+    "    replace=True,\n",
+    "    is_permanent=True,\n",
+    "    stage_location=\"@ML_STAGE\",\n",
+    "    packages=['joblib', 'snowflake-snowpark-python', 'snowflake-ml-python'],\n",
+    "    return_type=StringType()\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da45031a-917e-4f6d-a2e4-068879791819",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "gb_base_train_inference",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}','{{model_name}}', '{{base_version_name}}');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d18ea05-7d29-43a3-9baa-52509f3bb15e",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "gb_base_test_inference",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}','{{model_name}}', '{{base_version_name}}');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2550b-46c7-4eb7-adaa-64c345711b1e",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "gb_opt_train_inference",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}','{{model_name}}', '{{optimized_version_name}}');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8245f482-19e9-4961-9cb2-801bf5948d52",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "gb_opt_test_inference",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}','{{model_name}}', '{{optimized_version_name}}');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec05048c-a9d1-4ef9-bf39-5333f3fb56cb",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "see_preds",
+    "resultHeight": 251
+   },
+   "outputs": [],
+   "source": [
+    "select * FROM DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}} limit 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38a88ab4-7b22-414c-831d-5da2331e604b",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "set_up_monitoring_configs",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "# from snowflake.ml.monitoring.entities.model_monitor_config import ModelMonitorConfig, ModelMonitorSourceConfig\n",
+    "# # snowflake/ml/monitoring/entities/model_monitor_config.py\n",
+    "\n",
+    "# # Set up source/baseline table config for base model\n",
+    "# base_source_config = ModelMonitorSourceConfig(\n",
+    "#     baseline = \"DEMO_MORTGAGE_LENDING_TRAIN\",\n",
+    "#     source=\"DEMO_MORTGAGE_LENDING_TEST\",\n",
+    "#     timestamp_column=\"TIMESTAMP\",\n",
+    "#     prediction_score_columns=[\"XGB_BASE_PREDICTION\"],\n",
+    "#     actual_score_columns=[\"MORTGAGERESPONSE\"],\n",
+    "#     id_columns=[\"LOAN_ID\"]\n",
+    "# )\n",
+    "\n",
+    "# # Set up model config for tree booster\n",
+    "# base_monitor_config = ModelMonitorConfig(\n",
+    "#     model_version=mv_base,\n",
+    "#     model_function_name=\"predict\",\n",
+    "#     background_compute_warehouse_name=\"ML_WH\"\n",
+    "# )\n",
+    "\n",
+    "# # Set up source/baseline table config for opt model\n",
+    "# opt_source_config = ModelMonitorSourceConfig(\n",
+    "#     baseline = \"DEMO_MORTGAGE_LENDING_TRAIN\",\n",
+    "#     source=\"DEMO_MORTGAGE_LENDING_TEST\",\n",
+    "#     timestamp_column=\"TIMESTAMP\",\n",
+    "#     prediction_score_columns=[\"XGB_OPTIMIZED_PREDICTION\"],\n",
+    "#     actual_score_columns=[\"MORTGAGERESPONSE\"],\n",
+    "#     id_columns=[\"LOAN_ID\"]\n",
+    "# )\n",
+    "\n",
+    "# # Set up model config for linear booster\n",
+    "# opt_monitor_config = ModelMonitorConfig(\n",
+    "#     model_version=mv_opt,\n",
+    "#     model_function_name=\"predict\",\n",
+    "#     background_compute_warehouse_name=\"ML_WH\"\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5438465c-ae49-4f63-be40-c79118e7fa98",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "add_model_monitors",
+    "resultHeight": 0
+   },
+   "outputs": [],
+   "source": [
+    "# # Add a new ModelMonitor\n",
+    "# model_monitor = model_registry.add_monitor(\n",
+    "#     name=\"GB_TREE_MORTGAGE_LENDING_MODEL_MONITOR\", \n",
+    "#     source_config=tree_source_config,\n",
+    "#     model_monitor_config=tree_monitor_config,\n",
+    "# )\n",
+    "\n",
+    "\n",
+    "# model_monitor = model_registry.add_monitor(\n",
+    "#     name=\"GB_MORTGAGE_LENDING_MODEL_MONITOR\", \n",
+    "#     source_config=linear_source_config,\n",
+    "#     model_monitor_config=linear_monitor_config,\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f6be548-47cb-4a91-92ee-a5f42c41e756",
+   "metadata": {
+    "collapsed": false,
+    "language": "sql",
+    "name": "create_model_monitor_tree_SQL",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CREATE OR REPLACE MODEL MONITOR MORTGAGE_LENDING_BASE_MODEL_MONITOR\n",
+    "WITH\n",
+    "    MODEL={{model_name}}\n",
+    "    VERSION={{base_version_name}}\n",
+    "    FUNCTION=predict\n",
+    "    SOURCE=DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}\n",
+    "    BASELINE=DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}\n",
+    "    TIMESTAMP_COLUMN=TIMESTAMP\n",
+    "    PREDICTION_CLASS_COLUMNS=(XGB_BASE_PREDICTION)  \n",
+    "    ACTUAL_CLASS_COLUMNS=(MORTGAGERESPONSE)\n",
+    "    ID_COLUMNS=(LOAN_ID)\n",
+    "    WAREHOUSE=SMALL\n",
+    "    REFRESH_INTERVAL='1 min'\n",
+    "    AGGREGATION_WINDOW='1 day';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60965976-f17f-42bc-92ae-e43030bba54e",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "sql",
+    "name": "create_model_monitor_linear_SQL",
+    "resultHeight": 111
+   },
+   "outputs": [],
+   "source": [
+    "CREATE OR REPLACE MODEL MONITOR MORTGAGE_LENDING_OPTIMIZED_MODEL_MONITOR\n",
+    "WITH\n",
+    "    MODEL={{model_name}}\n",
+    "    VERSION={{optimized_version_name}}\n",
+    "    FUNCTION=predict\n",
+    "    SOURCE=DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}\n",
+    "    BASELINE=DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}\n",
+    "    TIMESTAMP_COLUMN=TIMESTAMP\n",
+    "    PREDICTION_CLASS_COLUMNS=(XGB_OPTIMIZED_PREDICTION)  \n",
+    "    ACTUAL_CLASS_COLUMNS=(MORTGAGERESPONSE)\n",
+    "    ID_COLUMNS=(LOAN_ID)\n",
+    "    WAREHOUSE=SMALL\n",
+    "    REFRESH_INTERVAL='1 min'\n",
+    "    AGGREGATION_WINDOW='1 day';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "537fc658-38f4-4c9a-980b-cf40ef61a268",
+   "metadata": {
+    "codeCollapsed": false,
+    "language": "sql",
+    "name": "compute_prediction_drift"
+   },
+   "outputs": [],
+   "source": [
+    "SELECT * FROM TABLE(MODEL_MONITOR_DRIFT_METRIC(\n",
+    "'MORTGAGE_LENDING_OPTIMIZED_MODEL_MONITOR', 'DIFFERENCE_OF_MEANS', 'XGB_BASE_PREDICTION', '1 DAY', TO_TIMESTAMP_TZ('2024-06-01'), TO_TIMESTAMP_TZ('2024-09-01')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b8f8d88-1ebe-4622-89ca-39bce08473d4",
+   "metadata": {
+    "collapsed": false,
+    "name": "SPCS_MD"
+   },
+   "source": [
+    "# SPCS Deployment setup (OPTIONAL) - **** REWRITE ****\n",
+    "## This is disabled by default but uncommenting the below code cells will allow a user to \n",
+    "\n",
+    "- ### Create a new compute pool with 3 XL CPU nodes\n",
+    "- ### Create a new image repository to store the container image for conatiner-based model scoring\n",
+    "- ### Deploys a service on top of our existing HPO model version\n",
+    "- ### Tests out inference on newly created container service\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c416a4d0-a95f-4702-9a61-26b61706eb11",
+   "metadata": {
+    "collapsed": false,
+    "language": "python",
+    "name": "define_spcs_vars"
+   },
+   "outputs": [],
+   "source": [
+    "# image_repo_name = \"MORTGAGE_LENDING_IMAGE_REPO_LLM\"\n",
+    "# cp_name = \"MORTGAGE_LENDING_INFERENCE_CP\"\n",
+    "# num_spcs_nodes = '3'\n",
+    "# spcs_instance_family = 'CPU_X64_L'\n",
+    "# service_name = 'MORTGAGE_LENDING_PREDICTION_SERVICE'\n",
+    "\n",
+    "# current_database = session.get_current_database().replace('\"', '')\n",
+    "# current_schema = session.get_current_schema().replace('\"', '')\n",
+    "# extended_image_repo_name = f\"{current_database}.{current_schema}.{image_repo_name}\"\n",
+    "# extended_service_name = f'{current_database}.{current_schema}.{service_name}'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e79ff8f0-e80e-4a94-8cd0-8567e4c901ce",
+   "metadata": {
+    "language": "python",
+    "name": "cell3"
+   },
+   "outputs": [],
+   "source": [
+    "# session.sql(f\"show image repositories\").collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "448f6702-8fb2-4aac-9e54-a8673c064074",
+   "metadata": {
+    "language": "python",
+    "name": "setup_compute_pool"
+   },
+   "outputs": [],
+   "source": [
+    "# session.sql(f\"alter compute pool if exists {cp_name} stop all\").collect()\n",
+    "# session.sql(f\"drop compute pool if exists {cp_name}\").collect()\n",
+    "# session.sql(f\"create compute pool {cp_name} min_nodes={num_spcs_nodes} max_nodes={num_spcs_nodes} instance_family={spcs_instance_family} auto_resume=True auto_suspend_secs=300\").collect()\n",
+    "# session.sql(f\"describe compute pool {cp_name}\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8537738c-7e11-42ea-847d-8871ddfe0539",
+   "metadata": {
+    "language": "python",
+    "name": "create_image_repo"
+   },
+   "outputs": [],
+   "source": [
+    "# session.sql(f\"create image repository if not exists {extended_image_repo_name}\").collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df47725b-e9e7-4f93-bdea-9db09794bd95",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": true,
+    "language": "python",
+    "name": "spcs_deploy_service"
+   },
+   "outputs": [],
+   "source": [
+    "# mv_opt.create_service(\n",
+    "#     service_name=extended_service_name,\n",
+    "#     service_compute_pool=cp_name,\n",
+    "#     image_repo=extended_image_repo_name,\n",
+    "#     ingress_enabled=True,\n",
+    "#     max_instances=int(num_spcs_nodes),\n",
+    "#     build_external_access_integration=\"ALLOW_ALL_INTEGRATION\"\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25c4f6d4-b16b-4448-bcf3-4f128ccfbe43",
+   "metadata": {
+    "language": "python",
+    "name": "cell14"
+   },
+   "outputs": [],
+   "source": [
+    "# model_registry.get_model(f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\").show_versions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f6dcb97-aa8f-467b-a939-63d1d3b70f58",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "view_services"
+   },
+   "outputs": [],
+   "source": [
+    "# mv_container = model_registry.get_model(f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\").default\n",
+    "# mv_container.list_services()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5eb9b1a-0741-4e9d-aaf4-2da26c44ffbd",
+   "metadata": {
+    "codeCollapsed": false,
+    "collapsed": false,
+    "language": "python",
+    "name": "run_SPCS_inference"
+   },
+   "outputs": [],
+   "source": [
+    "# mv_container.run(test, function_name = \"predict\", service_name = \"MORTGAGE_LENDING_PREDICTION_SERVICE\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce110000-1111-2222-3333-ffffff000036",
+   "metadata": {
+    "collapsed": false,
+    "jp-MarkdownHeadingCollapsed": true,
+    "name": "conclusion",
+    "resultHeight": 202,
+    "tags": []
+   },
+   "source": [
+    "## Conclusion **** RERWRITE ****\n",
+    "\n",
+    "#### 🛠️ Snowflake Feature Store tracks feature definitions and maintains lineage of sources and destinations 🛠️\n",
+    "#### 🚀 Snowflake Model Registry gives users a secure and flexible framework to deploy track and monitor models 🚀\n",
+    "#### 🔮 All model versions logged in the Model Registry can be accessed for inference, explainability, lineage tracking, visibility and more 🔮\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d63b5d33-5f36-4d60-85dd-77051d6c7836",
+   "metadata": {
+    "collapsed": false,
+    "name": "ARCHIVE"
+   },
+   "source": [
+    "# ARCHIVE BELOW"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f44c10-7b1d-48f1-95f4-ffadb23b0a4e",
+   "metadata": {
+    "collapsed": false,
+    "name": "cell2"
+   },
+   "source": [
+    "# Distributed model training\n",
+    "## For demonstrations sake - below we have an example doing distributed model training\n",
+    "### Snowflake will set up a ray cluster on all available nodes in your compute pool (CPU or GPU) and execute the distributed training job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a38e2451-0614-4c72-b75f-ad0d86ba9798",
+   "metadata": {
+    "language": "python",
+    "name": "cell1"
+   },
+   "outputs": [],
+   "source": [
+    "from snowflake.ml.modeling.distributors.xgboost.xgboost_estimator import XGBEstimator, XGBScalingConfig\n",
+    "from snowflake.ml.data.data_connector import DataConnector\n",
+    "dc = DataConnector.from_dataframe(train)\n",
+    "\n",
+    "#Specify Scaling Config \n",
+    "scaling_config = XGBScalingConfig(use_gpu=True)\n",
+    "\n",
+    "#Define distributed xgb estimator\n",
+    "dist_gpu_xgb = XGBEstimator(\n",
+    "    params = {\"booster\": \"gbtree\",\n",
+    "              \"n_estimators\":10,},\n",
+    "    scaling_config = scaling_config)\n",
+    "\n",
+    "dist_gpu_xgb.fit(dc,\n",
+    "                 input_cols = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).columns,\n",
+    "                 label_col = \"MORTGAGERESPONSE\")"
+   ]
+  }
+ ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python37 (ipykernel)",
+   "display_name": "py39_env",
    "language": "python",
    "name": "python3"
   },
@@ -15,1190 +2352,17 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.19"
   },
   "lastEditStatus": {
-   "notebookId": "5s7dygchm74m36mhv26l",
+   "authorEmail": "elliott.botwick@snowflake.com",
    "authorId": "5095547476787",
    "authorName": "EBOTWICK",
-   "authorEmail": "elliott.botwick@snowflake.com",
-   "sessionId": "e25f0adc-8281-48d7-8ada-e6f952e99af9",
-   "lastEditTime": 1741370809256
+   "lastEditTime": 1741370809256,
+   "notebookId": "5s7dygchm74m36mhv26l",
+   "sessionId": "e25f0adc-8281-48d7-8ada-e6f952e99af9"
   }
  },
- "nbformat_minor": 4,
  "nbformat": 4,
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "e79ae8e5-aec2-4276-9443-074c3a614142",
-   "metadata": {
-    "name": "INTRO_MD",
-    "collapsed": false
-   },
-   "source": "# ❄️ End-to-end ML Demo ❄️\n\nIn this worfklow we will work through the following elements of a typical tabular machine learning pipeline.\n\n### 1. Use Feature Store to track engineered features\n* Store feature defintions in feature store for reproducible computation of ML features\n      \n### 2. Train two Models using the Snowflake ML APIs\n* Baseline XGboost\n* XGboost with optimal hyper-parameters identified via Snowflake ML distributed HPO methods\n\n### 3. Register both models in Snowflake model registry\n* Explore model registry capabilities such as **metadata tracking, inference, and explainability**\n* Compare model metrics on train/test set to identify any issues of model performance or overfitting\n* Tag the best performing model version as 'default' version\n### 4. Set up Model Monitor to track 1 year of predicted and actual loan repayments\n* **Compute performance metrics** such a F1, Precision, Recall\n* **Inspect model drift** (i.e. how much has the average predicted repayment rate changed day-to-day)\n* **Compare models** side-by-side to understand which model should be used in production\n* Identify and understand **data issues**\n\n### 5. Track data and model lineage throughout\n* View and understand\n  * The **origin of the data** used for computed features\n  * The **data used** for model training\n  * The **available model versions** being monitored"
-  },
-  {
-   "cell_type": "code",
-   "id": "a2512cb5-15ae-40b2-84c7-8a44a9979670",
-   "metadata": {
-    "language": "python",
-    "name": "pip_installs",
-    "collapsed": true,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "!pip install shap",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "d78265b8-8baa-4136-a32a-32f3f620949d",
-   "metadata": {
-    "language": "python",
-    "name": "set_version_num",
-    "codeCollapsed": false,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#Update this VERSION_NUM to version your features, models etc!\nVERSION_NUM = '0'",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "name": "imports_and_session",
-    "language": "python",
-    "collapsed": false,
-    "resultHeight": 84,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "import pandas as pd\nimport numpy as np\nimport sklearn\nimport math\nimport pickle\nimport shap\nfrom datetime import datetime\nimport streamlit as st\nfrom xgboost import XGBClassifier\n\n# Snowpark ML\nfrom snowflake.ml.registry import Registry\nfrom snowflake.ml.modeling.tune import get_tuner_context\nfrom snowflake.ml.modeling import tune\nfrom entities import search_algorithm\n\n#Snowflake feature store\nfrom snowflake.ml.feature_store import FeatureStore, FeatureView, Entity, CreationMode\n\n# Snowpark session\nfrom snowflake.snowpark import DataFrame\nfrom snowflake.snowpark.functions import col, to_timestamp, min, max, month, dayofmonth, dayofweek, dayofyear, avg, median, date_add\nfrom snowflake.snowpark.types import IntegerType\nfrom snowflake.snowpark import Window\n\n#setup snowpark session\nfrom snowflake.snowpark.context import get_active_session\nsession = get_active_session()\nsession",
-   "id": "ce110000-1111-2222-3333-ffffff000000"
-  },
-  {
-   "cell_type": "code",
-   "id": "f8900d1d-a1f2-419b-ae7e-b194f268d904",
-   "metadata": {
-    "language": "python",
-    "name": "read_raw_data",
-    "resultHeight": 223,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "try:\n    print(\"Reading table data...\")\n    df = session.table(\"MORTGAGE_LENDING_DEMO_DATA\")\n    df.show(5)\nexcept:\n    print(\"Table not found! Uploading data to snowflake table\")\n    df_pandas = pd.read_csv(\"MORTGAGE_LENDING_DEMO_DATA.csv.zip\")\n    session.write_pandas(df_pandas, \"MORTGAGE_LENDING_DEMO_DATA\", auto_create_table=True)\n    df = session.table(\"MORTGAGE_LENDING_DEMO_DATA\")\n    df.show(5)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "60938b6f-bda7-4783-ae44-547bd34d98de",
-   "metadata": {
-    "name": "md1",
-    "collapsed": false
-   },
-   "source": "## Observe Snowflake Snowpark table properties"
-  },
-  {
-   "cell_type": "code",
-   "id": "a6654de7-6407-4ffe-a214-fd66078397ef",
-   "metadata": {
-    "language": "python",
-    "name": "see_timespan",
-    "collapsed": false,
-    "resultHeight": 111,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "df.select(min('TS'), max('TS'))",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "4b5a38cc-c479-4839-b0ae-9e5cb3e0facb",
-   "metadata": {
-    "language": "python",
-    "name": "find_timedelta",
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Get current date and time\ncurrent_time = datetime.now()\n# df_max_time = datetime.strptime(df.select(max(\"TS\")).collect()[0][0], \"%Y-%m-%d %H:%M:%S.%f\")\ndf_max_time = datetime.strptime(str(df.select(max(\"TS\")).collect()[0][0]), \"%Y-%m-%d %H:%M:%S.%f\")\n\n#Find delta between latest existing timestamp and today's date\ntimedelta = current_time- df_max_time\n\n#Update timestamps to represent last ~1 year from today's date\ndf.select(min(date_add(to_timestamp(\"TS\"), timedelta.days-1)), max(date_add(to_timestamp(\"TS\"), timedelta.days-1)))",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8aa46c7d-519b-422c-8932-9b031fc6b4bd",
-   "metadata": {
-    "name": "feat_eng_md",
-    "collapsed": false
-   },
-   "source": "## Feature Engineering with Snowpark APIs"
-  },
-  {
-   "cell_type": "code",
-   "id": "b355c0c4-9dc6-4faf-86b7-24d8d559e453",
-   "metadata": {
-    "language": "python",
-    "name": "define_features",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Create a dict with keys for feature names and values containing transform code\n\nfeature_eng_dict = dict()\n\n#Timstamp features\nfeature_eng_dict[\"TIMESTAMP\"] = date_add(to_timestamp(\"TS\"), timedelta.days-1)\nfeature_eng_dict[\"MONTH\"] = month(\"TIMESTAMP\")\nfeature_eng_dict[\"DAY_OF_YEAR\"] = dayofyear(\"TIMESTAMP\") \nfeature_eng_dict[\"DOTW\"] = dayofweek(\"TIMESTAMP\")\n\n# df= df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\n\n#Income and loan features\nfeature_eng_dict[\"LOAN_AMOUNT\"] = col(\"LOAN_AMOUNT_000s\")*1000\nfeature_eng_dict[\"INCOME\"] = col(\"APPLICANT_INCOME_000s\")*1000\nfeature_eng_dict[\"INCOME_LOAN_RATIO\"] = col(\"INCOME\")/col(\"LOAN_AMOUNT\")\n\ncounty_window_spec = Window.partition_by(\"COUNTY_NAME\")\nfeature_eng_dict[\"MEDIAN_COUNTY_INCOME\"] = median(\"INCOME\").over(county_window_spec)\nfeature_eng_dict[\"HIGH_INCOME_FLAG\"] = (col(\"INCOME\")>col(\"MEDIAN_COUNTY_INCOME\")).astype(IntegerType())\n\nday_window_spec = Window.order_by(\"DAY_OF_YEAR\").rows_between(-30,0)\nfeature_eng_dict[\"AVG_THIRTY_DAY_LOAN_AMOUNT\"] =  avg(\"LOAN_AMOUNT\").over(day_window_spec)\n\ndf = df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\ndf.show(3)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "b6c4ead8-25ac-46cc-9bd9-17eac2f796d5",
-   "metadata": {
-    "language": "python",
-    "name": "df_explain",
-    "resultHeight": 312,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "print(df.explain())",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "72d7645e-e0ac-4539-b132-54ce53431402",
-   "metadata": {
-    "name": "cell4",
-    "collapsed": false
-   },
-   "source": "## Create a Snowflake Feature Store"
-  },
-  {
-   "cell_type": "code",
-   "id": "abacdc71-9f2c-419f-8d50-3e8f89be367f",
-   "metadata": {
-    "language": "python",
-    "name": "define_feature_store",
-    "collapsed": false,
-    "resultHeight": 0,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "fs = FeatureStore(\n    session=session, \n    database=session.get_current_database(), \n    name=session.get_current_schema(), \n    default_warehouse=session.get_current_warehouse(),\n    creation_mode=CreationMode.CREATE_IF_NOT_EXIST\n)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "67480d6a-183f-4373-aaa8-d3ed8e80e11d",
-   "metadata": {
-    "language": "python",
-    "name": "list_entities",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "fs.list_entities()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d915406f-e52d-4baf-9f6c-b9e0e8d53e6e",
-   "metadata": {
-    "name": "FS_CONFIG_MD",
-    "collapsed": false
-   },
-   "source": "## Feature Store configuration\n- create/register entities of interest"
-  },
-  {
-   "cell_type": "code",
-   "id": "e91d6d39-7819-4825-8729-a3f19ca5cdf7",
-   "metadata": {
-    "language": "python",
-    "name": "load_or_register_entity",
-    "resultHeight": 38,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#First try to retrieve an existing entity definition, if not define a new one and register\ntry:\n    #retrieve existing entity\n    loan_id_entity = fs.get_entity('LOAN_ENTITY') \n    print('Retrieved existing entity')\nexcept:\n#define new entity\n    loan_id_entity = Entity(\n        name = \"LOAN_ENTITY\",\n        join_keys = [\"LOAN_ID\"],\n        desc = \"Features defined on a per loan level\")\n    #register\n    fs.register_entity(loan_id_entity)\n    print(\"Registered new entity\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "2820463f-0ea7-43ea-a500-9b034011887d",
-   "metadata": {
-    "language": "python",
-    "name": "create_feature_df",
-    "resultHeight": 217,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Create a dataframe with just the ID, timestamp, and engineered features. We will use this to define our feature view\nfeature_df = df.select([\"LOAN_ID\"]+list(feature_eng_dict.keys()))\nfeature_df.show(5)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5cf84fe3-4120-4092-b43d-8873da57d461",
-   "metadata": {
-    "name": "FS_MD",
-    "collapsed": false
-   },
-   "source": "Here, the feature store references an existing table. \n\nWe could also define the dataframe via the use of Snowpark APIs, and use that dataframe (or a function that returns a dataframe) as the feature view definition, below."
-  },
-  {
-   "cell_type": "code",
-   "id": "2b53364f-90c4-45b4-94ee-b2fde6f93475",
-   "metadata": {
-    "language": "python",
-    "name": "feature_veiw_creation",
-    "collapsed": false,
-    "resultHeight": 0,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#define and register feature view\nloan_fv = FeatureView(\n    name=\"Mortgage_Feature_View\",\n    entities=[loan_id_entity],\n    feature_df=feature_df,\n    timestamp_col=\"TIMESTAMP\",\n    refresh_freq=\"1 day\")\n\n#add feature level descriptions\n\nloan_fv = loan_fv.attach_feature_desc(\n    {\n        \"MONTH\": \"Month of loan\",\n        \"DAY_OF_YEAR\": \"Day of calendar year of loan\",\n        \"DOTW\": \"Day of the week of loan\",\n        \"LOAN_AMOUNT\": \"Loan amount in $USD\",\n        \"INCOME\": \"Household income in $USD\",\n        \"INCOME_LOAN_RATIO\": \"Ratio of LOAN_AMOUNT/INCOME\",\n        \"MEDIAN_COUNTY_INCOME\": \"Median household income aggregated at county level\",\n        \"HIGH_INCOME_FLAG\": \"Binary flag to indicate whether household income is higher than MEDIAN_COUNTY_INCOME\",\n        \"AVG_THIRTY_DAY_LOAN_AMOUNT\": \"Rolling 30 day average of LOAN_AMOUNT\"\n    }\n)\n\nloan_fv = fs.register_feature_view(loan_fv, version=VERSION_NUM, overwrite=True)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "18c3225b-b936-4aa7-81f2-27bbaeee1c0f",
-   "metadata": {
-    "language": "python",
-    "name": "show_feature_views",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "fs.list_feature_views()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "0f7a1aae-0bd2-4aad-b9ed-3347fc56b6ea",
-   "metadata": {
-    "language": "python",
-    "name": "create_feature_store_link",
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Create link to feature store UI to inspect newly created feature view!\n\norg_name = session.sql('SELECT CURRENT_ORGANIZATION_NAME()').collect()[0][0]\naccount_name = session.sql('SELECT CURRENT_ACCOUNT_NAME()').collect()[0][0]\ndb_name = session.sql('SELECT CURRENT_DATABASE()').collect()[0][0]\nschema_name = session.sql('SELECT CURRENT_SCHEMA()').collect()[0][0]\n\nst.write(f'https://app.snowflake.com/{org_name}/{account_name}/#/features/database/{db_name}/store/{schema_name}')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e96ff67f-bb04-40cb-8c14-11b5ebb2917d",
-   "metadata": {
-    "name": "FV_MD",
-    "collapsed": false
-   },
-   "source": "## Retrieve a Dataset from the featureview\n\nSnowflake Datasets are immutable, file-based objects that exist within your Snowpark session. \n\nThey can be written to persistent Snowflake objects as needed. "
-  },
-  {
-   "cell_type": "code",
-   "id": "535efc80-e4fc-41c5-98eb-5b5450bcf199",
-   "metadata": {
-    "language": "python",
-    "name": "generate_dataset",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "ds = fs.generate_dataset(\n    name=f\"MORTGAGE_DATASET_EXTENDED_FEATURES_{VERSION_NUM}\",\n    spine_df=df.select(\"LOAN_ID\", \"TIMESTAMP\", \"LOAN_PURPOSE_NAME\",\"MORTGAGERESPONSE\"), #only need the features used to fetch rest of feature view\n    features=[loan_fv],\n    spine_timestamp_col=\"TIMESTAMP\",\n    spine_label_cols=[\"MORTGAGERESPONSE\"]\n)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "ecdaa537-3fb9-476c-9153-3236edfdfcb3",
-   "metadata": {
-    "language": "python",
-    "name": "convert_dataset_to_snowpark_and_pandas",
-    "resultHeight": 239,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "ds_sp = ds.read.to_snowpark_dataframe()\nds_sp.show(5)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "b5e17036-7a69-4915-b025-49c900aeb46b",
-   "metadata": {
-    "language": "python",
-    "name": "one_hot_encoding",
-    "collapsed": false,
-    "resultHeight": 360,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "import snowflake.ml.modeling.preprocessing as snowml\nfrom snowflake.snowpark.types import StringType\n\nOHE_COLS = ds_sp.select([col.name for col in ds_sp.schema if col.datatype ==StringType()]).columns\nOHE_POST_COLS = [i+\"_OHE\" for i in OHE_COLS]\n\n\n# Encode categoricals to numeric columns\nsnowml_ohe = snowml.OneHotEncoder(input_cols=OHE_COLS, output_cols = OHE_COLS, drop_input_cols=True)\nds_sp_ohe = snowml_ohe.fit(ds_sp).transform(ds_sp)\n\n#Rename columns to avoid double nested quotes and white space chars\nrename_dict = {}\nfor i in ds_sp_ohe.columns:\n    if '\"' in i:\n        rename_dict[i] = i.replace('\"','').replace(' ', '_')\n\nds_sp_ohe = ds_sp_ohe.rename(rename_dict)\nds_sp_ohe.columns",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "d834f6f3-ce15-405e-8fec-1d1bb5c224a6",
-   "metadata": {
-    "language": "python",
-    "name": "train_test_split",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "train, test = ds_sp_ohe.random_split(weights=[0.70, 0.30], seed=0)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "a8ff103e-5314-4e95-87ba-d784b1102f36",
-   "metadata": {
-    "language": "python",
-    "name": "fill_na",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "train = train.fillna(0)\ntest = test.fillna(0)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "c917df7f-e277-4fbb-abf5-1a4433367e3b",
-   "metadata": {
-    "language": "python",
-    "name": "convert_data_to_pandas",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "train_pd = train.to_pandas()\ntest_pd = test.to_pandas()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a4a295d0-f4a5-48e1-8eab-4d3f67ba5942",
-   "metadata": {
-    "name": "cell11",
-    "collapsed": false
-   },
-   "source": "## Configure model"
-  },
-  {
-   "cell_type": "code",
-   "id": "5e4b5fba-b7a8-47ff-aaf6-076b9e78dcaf",
-   "metadata": {
-    "language": "python",
-    "name": "define_model",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Define model config\nxgb_base = XGBClassifier(\n    max_depth=50,\n    n_estimators=3,\n    learning_rate = 0.75,\n    booster = 'gbtree')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ed4b51d-e83c-4e1e-a9df-3b504e20abf0",
-   "metadata": {
-    "name": "cell12",
-    "collapsed": false
-   },
-   "source": "## Fit the model"
-  },
-  {
-   "cell_type": "code",
-   "id": "644f3295-2496-4fd0-ae95-922a78c5b944",
-   "metadata": {
-    "language": "python",
-    "name": "train_base_model",
-    "resultHeight": 1759,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Split train data into X, y\nX_train_pd = train_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1) #remove\ny_train_pd = train_pd.MORTGAGERESPONSE\n\n#train model\nxgb_base.fit(X_train_pd,y_train_pd)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b4ed8ace-06a4-4e74-a53c-e9a681f602bf",
-   "metadata": {
-    "name": "cell10",
-    "collapsed": false
-   },
-   "source": "Measure baseline performance of our first version\n\nNote that here, we simply use OSS methods from scikit-learn"
-  },
-  {
-   "cell_type": "code",
-   "id": "0c5ac861-fcf9-47b2-9c11-ec44ee2367e4",
-   "metadata": {
-    "language": "python",
-    "name": "compute_predictions_and_perf_metrics",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "from sklearn.metrics import f1_score, precision_score, recall_score\ntrain_preds_base = xgb_base.predict(X_train_pd) #update this line with correct ata\n\nf1_base_train = round(f1_score(y_train_pd, train_preds_base),4)\nprecision_base_train = round(precision_score(y_train_pd, train_preds_base),4)\nrecall_base_train = round(recall_score(y_train_pd, train_preds_base),4)\n\nprint(f'F1: {f1_base_train} \\nPrecision {precision_base_train} \\nRecall: {recall_base_train}')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "93777778-d2ba-42d5-88c4-a90ba18c5006",
-   "metadata": {
-    "name": "model_regisry_md",
-    "collapsed": false,
-    "resultHeight": 74
-   },
-   "source": "# Model Registry\n\n- Log models with important metadata\n- Manage model lifecycles\n- Serve models from Snowflake runtimes"
-  },
-  {
-   "cell_type": "code",
-   "id": "21678e59-deaf-4c2b-b01e-1c59fe31b10a",
-   "metadata": {
-    "language": "python",
-    "name": "define_model_registry",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Create a snowflake model registry object \nfrom snowflake.ml.registry import Registry\nfrom snowflake.ml._internal.utils import identifier\nfrom snowflake.ml.model import model_signature\n\ndb = identifier._get_unescaped_name(session.get_current_database())\nschema = identifier._get_unescaped_name(session.get_current_schema())\n\n\n# Define model name\nmodel_name = f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\"\n\n# Create a registry to log the model to\nmodel_registry = Registry(session=session, \n                          database_name=db, \n                          schema_name=schema,\n                          options={\"enable_monitoring\": True})",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "be41c3ac-49f0-4fd9-a557-9d8eb633f602",
-   "metadata": {
-    "language": "python",
-    "name": "register_model_version",
-    "collapsed": false,
-    "resultHeight": 229,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Deploy the base model to the model registry\nbase_version_name = 'XGB_BASE'\n\ntry:\n    mv_base = model_registry.get_model(model_name).version(base_version_name)\n    print(\"Found existing model version!\")\nexcept:\n    print(\"Logging new model version...\")\n    mv_base = model_registry.log_model(\n        model_name=model_name,\n        model=xgb_base, \n        version_name=base_version_name,\n        sample_input_data = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).limit(100), #using snowpark df to maintain lineage\n        comment = \"\"\"ML model for predicting loan approval likelihood.\n                    This model was trained using  xgboost classifier.\n                    Hyperparameters used were:a\n                    max_depth=50, n_estimators=3, learning_rate = 0.75, algorithm = gbtree.\n                    \"\"\",\n    )\n    mv_base.set_metric(metric_name=\"Train_F1_Score\", value=f1_base_train)\n    mv_base.set_metric(metric_name=\"Train_Precision_Score\", value=precision_base_train)\n    mv_base.set_metric(metric_name=\"Train_Recall_score\", value=recall_base_train)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "68e2ddab-b02a-4e05-8121-4e97e49e0eea",
-   "metadata": {
-    "language": "python",
-    "name": "cell16",
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "session.sql(\"CREATE OR REPLACE TAG PROD\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "9e0054df-0cd9-4e81-98b8-6564be86b4b9",
-   "metadata": {
-    "language": "python",
-    "name": "create_PROD_tag",
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Create tag for PROD model and apply \nsession.sql(\"CREATE OR REPLACE TAG PROD\")\nm = model_registry.get_model(model_name)\nm.set_tag(\"PROD\", base_version_name)\nm.comment = \"Loan approval prediction models\" #set model level comment",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "ac4e294e-929d-4399-b2bb-d5d2d1dd043e",
-   "metadata": {
-    "language": "python",
-    "name": "show_models",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "model_registry.show_models()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "e3dfb281-9751-48a1-a76e-43ffffd9d099",
-   "metadata": {
-    "language": "python",
-    "name": "show_model_versions",
-    "resultHeight": 146,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "model_registry.get_model(model_name).show_versions()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "eb1af8a1-7a92-455e-b9a1-8f2c699dfdeb",
-   "metadata": {
-    "language": "python",
-    "name": "print_model_version_and_metrics",
-    "resultHeight": 239,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "print(mv_base)\nprint(mv_base.show_metrics())",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "8ecdf05c-b3b5-4755-bdff-fd187ef07f58",
-   "metadata": {
-    "language": "python",
-    "name": "show_model_functions",
-    "resultHeight": 2133,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "mv_base.show_functions()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "bf495261-a8a7-46be-b9c8-3f099268d154",
-   "metadata": {
-    "language": "python",
-    "name": "predict_from_registry",
-    "resultHeight": 351,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "reg_preds = mv_base.run(test, function_name = \"predict\")\nreg_preds.show(10)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "efae2c0c-80d4-412c-8322-0e4ecceeb6f9",
-   "metadata": {
-    "language": "python",
-    "name": "cell17",
-    "codeCollapsed": false,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "reg_preds = reg_preds.rename(col('\"output_feature_0\"'), \"MORTGAGE_PREDICTION\")\nreg_preds.columns",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "9ef61447-10e7-4a38-a429-3da3facf9ce7",
-   "metadata": {
-    "language": "python",
-    "name": "compute_test_metrics",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#ds_sp_ohe = ds_sp_ohe.rename(col('\"LOAN_PURPOSE_NAME_Home improvement\"'), \"LOAN_PURPOSE_NAME_Home_improvement\")\n\npreds_pd = reg_preds.select([\"MORTGAGERESPONSE\", \"MORTGAGE_PREDICTION\"]).to_pandas()\nf1_base_test = round(f1_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\nprecision_base_test = round(precision_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\nrecall_base_test = round(recall_score(preds_pd.MORTGAGERESPONSE, preds_pd.MORTGAGE_PREDICTION),4)\n\n#log metrics to model registry model\nmv_base.set_metric(metric_name=\"Test_F1_Score\", value=f1_base_test)\nmv_base.set_metric(metric_name=\"Test_Precision_Score\", value=precision_base_test)\nmv_base.set_metric(metric_name=\"Test_Recall_score\", value=recall_base_test)\n\nprint(f'F1: {f1_base_test} \\nPrecision {precision_base_test} \\nRecall: {recall_base_test}')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b477885-35ce-486d-9e86-7d0cc9d48454",
-   "metadata": {
-    "name": "HPO_MD",
-    "collapsed": false
-   },
-   "source": "# Oh no! Our model's performance seems to have dropped off significantly from training to our test set. \n## This is evidence that our model is overfit - can we fix this with Distributed Hyperparameter Optimization??"
-  },
-  {
-   "cell_type": "code",
-   "id": "c47e068d-7e1d-4c74-8289-d03ea8ab3c7e",
-   "metadata": {
-    "language": "python",
-    "name": "setup_x_and_y",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "X_train = train.drop(\"MORTGAGERESPONSE\", \"TIMESTAMP\", \"LOAN_ID\")\ny_train = train.select(\"MORTGAGERESPONSE\")\nX_test = test.drop(\"MORTGAGERESPONSE\",\"TIMESTAMP\", \"LOAN_ID\")\ny_test = test.select(\"MORTGAGERESPONSE\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "fff76e05-38f5-47cf-ab5d-9eefed09bd71",
-   "metadata": {
-    "language": "python",
-    "name": "define_HPO_config",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "from snowflake.ml.data import DataConnector\nfrom snowflake.ml.modeling.tune import get_tuner_context\nfrom snowflake.ml.modeling import tune\nfrom entities import search_algorithm\n\n#Define dataset map\ndataset_map = {\n    \"x_train\": DataConnector.from_dataframe(X_train),\n    \"y_train\": DataConnector.from_dataframe(y_train),\n    \"x_test\": DataConnector.from_dataframe(X_test),\n    \"y_test\": DataConnector.from_dataframe(y_test)\n    }\n\n\n# Define a training function, with any models you choose within it.\ndef train_func():\n    # A context object provided by HPO API to expose data for the current HPO trial\n    tuner_context = get_tuner_context()\n    config = tuner_context.get_hyper_params()\n    dm = tuner_context.get_dataset_map()\n\n    model = XGBClassifier(**config, random_state=42)\n    model.fit(dm[\"x_train\"].to_pandas().sort_index(), dm[\"y_train\"].to_pandas().sort_index())\n    f1_metric = f1_score(\n        dm[\"y_train\"].to_pandas().sort_index(), model.predict(dm[\"x_train\"].to_pandas().sort_index())\n    )\n    tuner_context.report(metrics={\"f1_score\": f1_metric}, model=model)\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space={\n        \"max_depth\": tune.randint(1, 20),\n        \"learning_rate\": tune.uniform(0.01, 0.1),\n        \"n_estimators\": tune.randint(50, 100),\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"f1_score\",\n        mode=\"max\",\n        search_alg=search_algorithm.RandomSearch(random_state=101),\n        num_trials=8, #run 8 trial runs\n        max_concurrent_trials=4, #use 4 gpus concurrently\n    ),\n)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "14b88e99-9d2a-44cd-81f9-d53fd1321daf",
-   "metadata": {
-    "language": "python",
-    "name": "run_hpo",
-    "collapsed": true,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "tuner_results = tuner.run(dataset_map=dataset_map)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "9ee37c42-3de7-476a-b7c0-d56952dac385",
-   "metadata": {
-    "language": "python",
-    "name": "inspect_hpo_params",
-    "codeCollapsed": false,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "tuned_model = tuner_results.best_model\ntuned_model",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "94b4a6c2-674e-4d02-afdb-8ebf10cffdc4",
-   "metadata": {
-    "language": "python",
-    "name": "compute_hpo_train_predictions_and_metrics",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Generate predictions\nxgb_opt_preds = tuned_model.predict(train_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1))\n\n#Generate performance metrics\nf1_opt_train = round(f1_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\nprecision_opt_train = round(precision_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\nrecall_opt_train = round(recall_score(train_pd.MORTGAGERESPONSE, xgb_opt_preds),4)\n\nprint(f'Train Results: \\nF1: {f1_opt_train} \\nPrecision {precision_opt_train} \\nRecall: {recall_opt_train}')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "dee80c48-d521-4b77-8841-54ba35ecd4b6",
-   "metadata": {
-    "language": "python",
-    "name": "compute_hpo_test_predictions_and_metrics",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Generate test predictions\nxgb_opt_preds_test = tuned_model.predict(test_pd.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"],axis=1))\n\n#Generate performance metrics on test data\nf1_opt_test = round(f1_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\nprecision_opt_test = round(precision_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\nrecall_opt_test = round(recall_score(test_pd.MORTGAGERESPONSE, xgb_opt_preds_test),4)\n\nprint(f'Test Results: \\nF1: {f1_opt_test} \\nPrecision {precision_opt_test} \\nRecall: {recall_opt_test}')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "89a1a670-52e3-4d77-ac3a-db830e22fdcf",
-   "metadata": {
-    "name": "HPO_performance_reaction",
-    "collapsed": false
-   },
-   "source": "# Here we see the HPO model has a more modest train accuracy than our base model - but the peformance doesn't drop off during testing"
-  },
-  {
-   "cell_type": "code",
-   "id": "d501cf7d-4965-4b9f-8b16-edab897d0e18",
-   "metadata": {
-    "language": "python",
-    "name": "log_hpo_model",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#Log the optimized model to the model registry\noptimized_version_name = 'XGB_Optimized'\n\ntry:\n    mv_opt = model_registry.get_model(model_name).version(optimized_version_name)\n    print(\"Found existing model version!\")\nexcept:\n    print(\"Logging new model version...\")\n    mv_opt = model_registry.log_model(\n        model_name=model_name,\n        model=tuned_model, \n        version_name=optimized_version_name,\n        sample_input_data = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).limit(100),\n        comment = \"snow ml model built off feature store using HPO model\",\n    )\n    mv_opt.set_metric(metric_name=\"Train_F1_Score\", value=f1_opt_train)\n    mv_opt.set_metric(metric_name=\"Train_Precision_Score\", value=precision_opt_train)\n    mv_opt.set_metric(metric_name=\"Train_Recall_score\", value=recall_opt_train)\n\n    mv_opt.set_metric(metric_name=\"Test_F1_Score\", value=f1_opt_test)\n    mv_opt.set_metric(metric_name=\"Test_Precision_Score\", value=precision_opt_test)\n    mv_opt.set_metric(metric_name=\"Test_Recall_score\", value=recall_opt_test)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "c4c028b9-b590-45b4-9884-35ee206bca0d",
-   "metadata": {
-    "language": "python",
-    "name": "inspect_current_default_version",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#Here we see the BASE version is our default version\nmodel_registry.get_model(model_name).default",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "04ac97a9-7af4-4331-bb0d-cf6ecc4a77f6",
-   "metadata": {
-    "language": "python",
-    "name": "promote_optimized_version_to_default",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "#Now we'll set the optimized model to be the default model version going forward\nmodel_registry.get_model(model_name).default = optimized_version_name",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "c04efcee-27e6-4423-b669-849bec7cc8fb",
-   "metadata": {
-    "language": "python",
-    "name": "see_updated_model_versions",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#Now we see our optimized version we have now recently promoted to our DEFAULT model version\nmodel_registry.get_model(model_name).default",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "8cc92f7f-5f02-4cc5-82d0-758f65f2d485",
-   "metadata": {
-    "language": "python",
-    "name": "update_model_tags",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#we'll now update the PROD tagged model to be the optimized model version rather than our overfit base version\nm.unset_tag(\"PROD\")\nm.set_tag(\"PROD\", optimized_version_name)\nm.show_tags()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "05fff15e-5f49-4d4f-a02a-93e8f3114b11",
-   "metadata": {
-    "name": "explainability_MD",
-    "collapsed": false
-   },
-   "source": "## Now that we've deployed some model versions and tested inference... \n# Let's explain our models!\n- ### Snowflake offers built in explainability capabilities on top of models logged to the model registry\n- ### In the below section we'll generate shapley values using these built in functions to understand how input features impact our model's behavior"
-  },
-  {
-   "cell_type": "code",
-   "id": "914f5cd6-d254-42d4-a0be-9848c9d09d4a",
-   "metadata": {
-    "language": "python",
-    "name": "compute_shap_vals",
-    "resultHeight": 0,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#create a sample of 1000 records\ntest_pd_sample=test_pd.rename(columns=rename_dict).sample(n=1000, random_state = 100).reset_index(drop=True)\n\n#Compute shapley values for each model\nbase_shap_pd = mv_base.run(test_pd_sample, function_name=\"explain\")\nopt_shap_pd = mv_opt.run(test_pd_sample, function_name=\"explain\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "f74e0dcc-a850-474a-b475-f05a77619731",
-   "metadata": {
-    "language": "python",
-    "name": "base_shap_summary_plot",
-    "resultHeight": 571,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "import shap \n\nshap.summary_plot(np.array(base_shap_pd.astype(float)), \n                  test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1), \n                  feature_names = test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1).columns)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "67469a84-3d44-49e4-8d6e-5cd8a6e8a633",
-   "metadata": {
-    "language": "python",
-    "name": "cell8"
-   },
-   "outputs": [],
-   "source": "shap.summary_plot(np.array(opt_shap_pd.astype(float)), \n                  test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1), \n                  feature_names = test_pd_sample.drop([\"LOAN_ID\",\"MORTGAGERESPONSE\", \"TIMESTAMP\"], axis=1).columns)",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "f3a0d4c3-750c-4ae0-9812-85b677db6986",
-   "metadata": {
-    "language": "python",
-    "name": "create_all_shap_dfs",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#Merge shap vals and actual vals together for easier plotting below\nall_shap_base = test_pd_sample.merge(base_shap_pd, right_index=True, left_index=True, how='outer')\nall_shap_opt = test_pd_sample.merge(opt_shap_pd, right_index=True, left_index=True, how='outer')",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "938441fd-9ae3-4f97-9a54-b7e4c74738ac",
-   "metadata": {
-    "language": "python",
-    "name": "plot_income_explanation"
-   },
-   "outputs": [],
-   "source": "import seaborn as sns\nimport matplotlib.pyplot as plt\n\n#filter data down to strip outliers\nasb_filtered = all_shap_base[(all_shap_base.INCOME>0) & (all_shap_base.INCOME<250000)]\naso_filtered = all_shap_opt[(all_shap_opt.INCOME>0) & (all_shap_opt.INCOME<250000)]\n\n# Set up the figure\nfig, axes = plt.subplots(1, 2, figsize=(10, 6))\nfig.suptitle(\"INCOME EXPLANATION\")\n# Plot side-by-side boxplots\nsns.scatterplot(data = asb_filtered, x ='INCOME', y = 'INCOME_explanation', ax=axes[0])\nsns.regplot(data = asb_filtered, x =\"INCOME\", y = 'INCOME_explanation', scatter=False, color='red', line_kws={\"lw\":2},ci =100, lowess=False, ax =axes[0])\n\naxes[0].set_title('Base Model')\nsns.scatterplot(data = aso_filtered, x ='INCOME', y = 'INCOME_explanation',color = \"orange\", ax = axes[1])\nsns.regplot(data = aso_filtered, x =\"INCOME\", y = 'INCOME_explanation', scatter=False, color='blue', line_kws={\"lw\":2},ci =100, lowess=False, ax =axes[1])\naxes[1].set_title('Opt Model')\n\n# Customize and show the plot\nfor ax in axes:\n    ax.set_xlabel(\"Income\")\n    ax.set_ylabel(\"Influence\")\nplt.tight_layout()\nplt.show()\n",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "2298b1f8-0495-42e1-b668-0dcd03d8bb7c",
-   "metadata": {
-    "language": "python",
-    "name": "plot_loan_amount_explanation",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "#filter data down to strip outliers\nasb_filtered = all_shap_base[all_shap_base.LOAN_AMOUNT<2000000]\naso_filtered = all_shap_opt[all_shap_opt.LOAN_AMOUNT<2000000]\n\n\n# Set up the figure\nfig, axes = plt.subplots(1, 2, figsize=(10, 6))\nfig.suptitle(\"LOAN_AMOUNT EXPLANATION\")\n# Plot side-by-side boxplots\nsns.scatterplot(data = asb_filtered, x ='LOAN_AMOUNT', y = 'LOAN_AMOUNT_explanation', ax=axes[0])\nsns.regplot(data = asb_filtered, x =\"LOAN_AMOUNT\", y = 'LOAN_AMOUNT_explanation', scatter=False, color='red', line_kws={\"lw\":2},ci =100, lowess=True, ax =axes[0])\naxes[0].set_title('Base Model')\n\nsns.scatterplot(data = aso_filtered, x ='LOAN_AMOUNT', y = 'LOAN_AMOUNT_explanation',color = \"orange\", ax = axes[1])\nsns.regplot(data = aso_filtered, x =\"LOAN_AMOUNT\", y = 'LOAN_AMOUNT_explanation', scatter=False, color='blue', line_kws={\"lw\":2},ci =100, lowess=True, ax =axes[1])\naxes[1].set_title('Opt Model')\n\n# Customize and show the plot\nfor ax in axes:\n    ax.set_xlabel(\"LOAN_AMOUNT\")\n    ax.set_ylabel(\"Influence\")\n    # ax.set_xlim((0,10000))\nplt.tight_layout()\nplt.show()\n",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "14a03aa9-1f1a-4a4e-809e-b22e438d72aa",
-   "metadata": {
-    "language": "python",
-    "name": "plot_home_purchase_explanation",
-    "resultHeight": 851,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "# Set up the figure\nfig, axes = plt.subplots(1, 2, figsize=(10, 6))\nfig.suptitle(\"HOME PURCHASE LOAN EXPLANATION\")\n# Plot side-by-side boxplots\nsns.boxplot(data = all_shap_base, x ='LOAN_PURPOSE_NAME_HOME_PURCHASE', y = 'LOAN_PURPOSE_NAME_HOME_PURCHASE_explanation',\n            hue='LOAN_PURPOSE_NAME_HOME_PURCHASE', width=0.8, ax=axes[0])\naxes[0].set_title('Base Model')\nsns.boxplot(data = all_shap_opt, x ='LOAN_PURPOSE_NAME_HOME_PURCHASE', y = 'LOAN_PURPOSE_NAME_HOME_PURCHASE_explanation',\n            hue='LOAN_PURPOSE_NAME_HOME_PURCHASE', width=0.4, ax = axes[1])\naxes[1].set_title('Opt Model')\n\n# Customize and show the plot\nfor ax in axes:\n    ax.set_xlabel(\"Home PURCHASE Loan (1 = True)\")\n    ax.set_ylabel(\"Influence\")\n    ax.legend(loc='upper right')\n\nplt.show()\n",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "66ea7aad-4e48-4666-a48c-ddc39331cb1f",
-   "metadata": {
-    "language": "python",
-    "name": "plot_home_imrprovement_explanation",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "# Set up the figure\nfig, axes = plt.subplots(1, 2, figsize=(10, 6))\nfig.suptitle(\"HOME IMPROVEMENT LOAN EXPLANATION\")\n# Plot side-by-side boxplots\nsns.boxplot(data = all_shap_base, x ='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', y = 'LOAN_PURPOSE_NAME_HOME_IMPROVEMENT_explanation',\n            hue='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', width=0.8, ax=axes[0])\naxes[0].set_title('Base Model')\nsns.boxplot(data = all_shap_opt, x ='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', y = 'LOAN_PURPOSE_NAME_HOME_IMPROVEMENT_explanation',\n            hue='LOAN_PURPOSE_NAME_HOME_IMPROVEMENT', width=0.4, ax = axes[1])\naxes[1].set_title('Opt Model')\n\n# Customize and show the plot\nfor ax in axes:\n    ax.set_xlabel(\"Home Improvement Loan (1 = True)\")\n    ax.set_ylabel(\"Influence\")\n    ax.legend(loc='upper right')\n\nplt.show()\n",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "df7a9ccc-e785-4a82-b9e9-97fd44d5acf2",
-   "metadata": {
-    "name": "Monitoring_section",
-    "collapsed": false,
-    "resultHeight": 74
-   },
-   "source": "# Model Monitoring setup"
-  },
-  {
-   "cell_type": "code",
-   "id": "e0751bdd-6c24-4c65-9247-aa90ebc1d376",
-   "metadata": {
-    "language": "python",
-    "name": "create_table_from_test_data",
-    "resultHeight": 0,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "train.write.save_as_table(f\"DEMO_MORTGAGE_LENDING_TRAIN_{VERSION_NUM}\", mode=\"overwrite\")\ntest.write.save_as_table(f\"DEMO_MORTGAGE_LENDING_TEST_{VERSION_NUM}\", mode=\"overwrite\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "aabdf2be-87f8-4556-aa42-22e4a70515e1",
-   "metadata": {
-    "language": "python",
-    "name": "create_stage",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "session.sql(\"CREATE stage IF NOT EXISTS ML_STAGE\").collect()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "21b2c090-5cc8-4847-982a-fb9b5e427616",
-   "metadata": {
-    "language": "python",
-    "name": "define_sproc",
-    "collapsed": false,
-    "resultHeight": 495,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "from snowflake import snowpark\nfrom snowflake.ml.registry import Registry\nimport joblib\nimport os\nimport logging\nfrom snowflake.ml.modeling.pipeline import Pipeline\nimport snowflake.ml.modeling.preprocessing as pp\nfrom snowflake.snowpark.types import StringType, IntegerType\nimport snowflake.snowpark.functions as F\n\n\ndef demo_inference_sproc(session: snowpark.Session, table_name: str, modelname: str, modelversion: str) -> str:\n    \n    database=session.get_current_database()\n    schema=session.get_current_schema()\n    reg = Registry(session=session)\n    m = reg.get_model(model_name)  # Fetch the model using the registry\n    mv = m.version(modelversion)\n    \n    input_table_name=table_name\n    pred_col = f'{modelversion}_PREDICTION'\n\n    # Read the input table to a dataframe\n    df = session.table(input_table_name)\n    results = mv.run(df, function_name=\"predict\").select(\"LOAN_ID\",'\"output_feature_0\"').withColumnRenamed('\"output_feature_0\"', pred_col)\n    # 'results' is the output DataFrame with predictions\n\n    final = df.join(results, on=\"LOAN_ID\", how=\"full\")\n    # Write results back to Snowflake table\n    final.write.save_as_table(table_name, mode='overwrite',enable_schema_evolution=True)\n\n    return \"Success\"\n\n# Register the stored procedure\nsession.sproc.register(\n    func=demo_inference_sproc,\n    name=\"model_inference_sproc\",\n    replace=True,\n    is_permanent=True,\n    stage_location=\"@ML_STAGE\",\n    packages=['joblib', 'snowflake-snowpark-python', 'snowflake-ml-python'],\n    return_type=StringType()\n)\n",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "da45031a-917e-4f6d-a2e4-068879791819",
-   "metadata": {
-    "language": "sql",
-    "name": "gb_base_train_inference",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}','{{model_name}}', '{{base_version_name}}');",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "0d18ea05-7d29-43a3-9baa-52509f3bb15e",
-   "metadata": {
-    "language": "sql",
-    "name": "gb_base_test_inference",
-    "collapsed": false,
-    "resultHeight": 111,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}','{{model_name}}', '{{base_version_name}}');",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "c1d2550b-46c7-4eb7-adaa-64c345711b1e",
-   "metadata": {
-    "language": "sql",
-    "name": "gb_opt_train_inference",
-    "collapsed": false,
-    "resultHeight": 111,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}','{{model_name}}', '{{optimized_version_name}}');",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "8245f482-19e9-4961-9cb2-801bf5948d52",
-   "metadata": {
-    "language": "sql",
-    "name": "gb_opt_test_inference",
-    "collapsed": false,
-    "resultHeight": 111,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "CALL model_inference_sproc('DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}','{{model_name}}', '{{optimized_version_name}}');",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "ec05048c-a9d1-4ef9-bf39-5333f3fb56cb",
-   "metadata": {
-    "language": "sql",
-    "name": "see_preds",
-    "resultHeight": 251,
-    "codeCollapsed": false,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "select * FROM DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}} limit 10",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "38a88ab4-7b22-414c-831d-5da2331e604b",
-   "metadata": {
-    "language": "python",
-    "name": "set_up_monitoring_configs",
-    "resultHeight": 0,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "# from snowflake.ml.monitoring.entities.model_monitor_config import ModelMonitorConfig, ModelMonitorSourceConfig\n# # snowflake/ml/monitoring/entities/model_monitor_config.py\n\n# # Set up source/baseline table config for base model\n# base_source_config = ModelMonitorSourceConfig(\n#     baseline = \"DEMO_MORTGAGE_LENDING_TRAIN\",\n#     source=\"DEMO_MORTGAGE_LENDING_TEST\",\n#     timestamp_column=\"TIMESTAMP\",\n#     prediction_score_columns=[\"XGB_BASE_PREDICTION\"],\n#     actual_score_columns=[\"MORTGAGERESPONSE\"],\n#     id_columns=[\"LOAN_ID\"]\n# )\n\n# # Set up model config for tree booster\n# base_monitor_config = ModelMonitorConfig(\n#     model_version=mv_base,\n#     model_function_name=\"predict\",\n#     background_compute_warehouse_name=\"ML_WH\"\n# )\n\n# # Set up source/baseline table config for opt model\n# opt_source_config = ModelMonitorSourceConfig(\n#     baseline = \"DEMO_MORTGAGE_LENDING_TRAIN\",\n#     source=\"DEMO_MORTGAGE_LENDING_TEST\",\n#     timestamp_column=\"TIMESTAMP\",\n#     prediction_score_columns=[\"XGB_OPTIMIZED_PREDICTION\"],\n#     actual_score_columns=[\"MORTGAGERESPONSE\"],\n#     id_columns=[\"LOAN_ID\"]\n# )\n\n# # Set up model config for linear booster\n# opt_monitor_config = ModelMonitorConfig(\n#     model_version=mv_opt,\n#     model_function_name=\"predict\",\n#     background_compute_warehouse_name=\"ML_WH\"\n# )",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "5438465c-ae49-4f63-be40-c79118e7fa98",
-   "metadata": {
-    "language": "python",
-    "name": "add_model_monitors",
-    "resultHeight": 0,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "# # Add a new ModelMonitor\n# model_monitor = model_registry.add_monitor(\n#     name=\"GB_TREE_MORTGAGE_LENDING_MODEL_MONITOR\", \n#     source_config=tree_source_config,\n#     model_monitor_config=tree_monitor_config,\n# )\n\n\n# model_monitor = model_registry.add_monitor(\n#     name=\"GB_MORTGAGE_LENDING_MODEL_MONITOR\", \n#     source_config=linear_source_config,\n#     model_monitor_config=linear_monitor_config,\n# )",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "2f6be548-47cb-4a91-92ee-a5f42c41e756",
-   "metadata": {
-    "language": "sql",
-    "name": "create_model_monitor_tree_SQL",
-    "resultHeight": 111,
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "CREATE OR REPLACE MODEL MONITOR MORTGAGE_LENDING_BASE_MODEL_MONITOR\nWITH\n    MODEL={{model_name}}\n    VERSION={{base_version_name}}\n    FUNCTION=predict\n    SOURCE=DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}\n    BASELINE=DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}\n    TIMESTAMP_COLUMN=TIMESTAMP\n    PREDICTION_CLASS_COLUMNS=(XGB_BASE_PREDICTION)  \n    ACTUAL_CLASS_COLUMNS=(MORTGAGERESPONSE)\n    ID_COLUMNS=(LOAN_ID)\n    WAREHOUSE=SMALL\n    REFRESH_INTERVAL='1 min'\n    AGGREGATION_WINDOW='1 day';",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "60965976-f17f-42bc-92ae-e43030bba54e",
-   "metadata": {
-    "language": "sql",
-    "name": "create_model_monitor_linear_SQL",
-    "resultHeight": 111,
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "CREATE OR REPLACE MODEL MONITOR MORTGAGE_LENDING_OPTIMIZED_MODEL_MONITOR\nWITH\n    MODEL={{model_name}}\n    VERSION={{optimized_version_name}}\n    FUNCTION=predict\n    SOURCE=DEMO_MORTGAGE_LENDING_TEST_{{VERSION_NUM}}\n    BASELINE=DEMO_MORTGAGE_LENDING_TRAIN_{{VERSION_NUM}}\n    TIMESTAMP_COLUMN=TIMESTAMP\n    PREDICTION_CLASS_COLUMNS=(XGB_OPTIMIZED_PREDICTION)  \n    ACTUAL_CLASS_COLUMNS=(MORTGAGERESPONSE)\n    ID_COLUMNS=(LOAN_ID)\n    WAREHOUSE=SMALL\n    REFRESH_INTERVAL='1 min'\n    AGGREGATION_WINDOW='1 day';",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "537fc658-38f4-4c9a-980b-cf40ef61a268",
-   "metadata": {
-    "language": "sql",
-    "name": "compute_prediction_drift",
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "SELECT * FROM TABLE(MODEL_MONITOR_DRIFT_METRIC(\n'MORTGAGE_LENDING_OPTIMIZED_MODEL_MONITOR', 'DIFFERENCE_OF_MEANS', 'XGB_BASE_PREDICTION', '1 DAY', TO_TIMESTAMP_TZ('2024-06-01'), TO_TIMESTAMP_TZ('2024-09-01')))",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7b8f8d88-1ebe-4622-89ca-39bce08473d4",
-   "metadata": {
-    "name": "SPCS_MD",
-    "collapsed": false
-   },
-   "source": "# SPCS Deployment setup (OPTIONAL) - **** REWRITE ****\n## This is disabled by default but uncommenting the below code cells will allow a user to \n\n- ### Create a new compute pool with 3 XL CPU nodes\n- ### Create a new image repository to store the container image for conatiner-based model scoring\n- ### Deploys a service on top of our existing HPO model version\n- ### Tests out inference on newly created container service\n"
-  },
-  {
-   "cell_type": "code",
-   "id": "c416a4d0-a95f-4702-9a61-26b61706eb11",
-   "metadata": {
-    "language": "python",
-    "name": "define_spcs_vars",
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": "# image_repo_name = \"MORTGAGE_LENDING_IMAGE_REPO_LLM\"\n# cp_name = \"MORTGAGE_LENDING_INFERENCE_CP\"\n# num_spcs_nodes = '3'\n# spcs_instance_family = 'CPU_X64_L'\n# service_name = 'MORTGAGE_LENDING_PREDICTION_SERVICE'\n\n# current_database = session.get_current_database().replace('\"', '')\n# current_schema = session.get_current_schema().replace('\"', '')\n# extended_image_repo_name = f\"{current_database}.{current_schema}.{image_repo_name}\"\n# extended_service_name = f'{current_database}.{current_schema}.{service_name}'",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "e79ff8f0-e80e-4a94-8cd0-8567e4c901ce",
-   "metadata": {
-    "language": "python",
-    "name": "cell3"
-   },
-   "outputs": [],
-   "source": "# session.sql(f\"show image repositories\").collect()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "448f6702-8fb2-4aac-9e54-a8673c064074",
-   "metadata": {
-    "language": "python",
-    "name": "setup_compute_pool"
-   },
-   "outputs": [],
-   "source": "# session.sql(f\"alter compute pool if exists {cp_name} stop all\").collect()\n# session.sql(f\"drop compute pool if exists {cp_name}\").collect()\n# session.sql(f\"create compute pool {cp_name} min_nodes={num_spcs_nodes} max_nodes={num_spcs_nodes} instance_family={spcs_instance_family} auto_resume=True auto_suspend_secs=300\").collect()\n# session.sql(f\"describe compute pool {cp_name}\").show()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "8537738c-7e11-42ea-847d-8871ddfe0539",
-   "metadata": {
-    "language": "python",
-    "name": "create_image_repo"
-   },
-   "outputs": [],
-   "source": "# session.sql(f\"create image repository if not exists {extended_image_repo_name}\").collect()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "df47725b-e9e7-4f93-bdea-9db09794bd95",
-   "metadata": {
-    "language": "python",
-    "name": "spcs_deploy_service",
-    "collapsed": true,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "# mv_opt.create_service(\n#     service_name=extended_service_name,\n#     service_compute_pool=cp_name,\n#     image_repo=extended_image_repo_name,\n#     ingress_enabled=True,\n#     max_instances=int(num_spcs_nodes),\n#     build_external_access_integration=\"ALLOW_ALL_INTEGRATION\"\n# )",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "25c4f6d4-b16b-4448-bcf3-4f128ccfbe43",
-   "metadata": {
-    "language": "python",
-    "name": "cell14"
-   },
-   "outputs": [],
-   "source": "# model_registry.get_model(f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\").show_versions()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "3f6dcb97-aa8f-467b-a939-63d1d3b70f58",
-   "metadata": {
-    "language": "python",
-    "name": "view_services",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "# mv_container = model_registry.get_model(f\"MORTGAGE_LENDING_MLOPS_{VERSION_NUM}\").default\n# mv_container.list_services()",
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "id": "c5eb9b1a-0741-4e9d-aaf4-2da26c44ffbd",
-   "metadata": {
-    "language": "python",
-    "name": "run_SPCS_inference",
-    "collapsed": false,
-    "codeCollapsed": false
-   },
-   "outputs": [],
-   "source": "# mv_container.run(test, function_name = \"predict\", service_name = \"MORTGAGE_LENDING_PREDICTION_SERVICE\")",
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
-    "tags": [],
-    "name": "conclusion",
-    "resultHeight": 202,
-    "collapsed": false
-   },
-   "source": "## Conclusion **** RERWRITE ****\n\n#### 🛠️ Snowflake Feature Store tracks feature definitions and maintains lineage of sources and destinations 🛠️\n#### 🚀 Snowflake Model Registry gives users a secure and flexible framework to deploy track and monitor models 🚀\n#### 🔮 All model versions logged in the Model Registry can be accessed for inference, explainability, lineage tracking, visibility and more 🔮\n",
-   "id": "ce110000-1111-2222-3333-ffffff000036"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d63b5d33-5f36-4d60-85dd-77051d6c7836",
-   "metadata": {
-    "name": "ARCHIVE",
-    "collapsed": false
-   },
-   "source": "# ARCHIVE BELOW"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "52f44c10-7b1d-48f1-95f4-ffadb23b0a4e",
-   "metadata": {
-    "name": "cell2",
-    "collapsed": false
-   },
-   "source": "# Distributed model training\n## For demonstrations sake - below we have an example doing distributed model training\n### Snowflake will set up a ray cluster on all available nodes in your compute pool (CPU or GPU) and execute the distributed training job"
-  },
-  {
-   "cell_type": "code",
-   "id": "a38e2451-0614-4c72-b75f-ad0d86ba9798",
-   "metadata": {
-    "language": "python",
-    "name": "cell1"
-   },
-   "outputs": [],
-   "source": "from snowflake.ml.modeling.distributors.xgboost.xgboost_estimator import XGBEstimator, XGBScalingConfig\nfrom snowflake.ml.data.data_connector import DataConnector\ndc = DataConnector.from_dataframe(train)\n\n#Specify Scaling Config \nscaling_config = XGBScalingConfig(use_gpu=True)\n\n#Define distributed xgb estimator\ndist_gpu_xgb = XGBEstimator(\n    params = {\"booster\": \"gbtree\",\n              \"n_estimators\":10,},\n    scaling_config = scaling_config)\n\ndist_gpu_xgb.fit(dc,\n                 input_cols = train.drop([\"TIMESTAMP\", \"LOAN_ID\", \"MORTGAGERESPONSE\"]).columns,\n                 label_col = \"MORTGAGERESPONSE\")",
-   "execution_count": null
-  }
- ]
+ "nbformat_minor": 4
 }

--- a/train_deploy_monitor_ML_in_snowflake.ipynb
+++ b/train_deploy_monitor_ML_in_snowflake.ipynb
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "ce110000-1111-2222-3333-ffffff000000",
    "metadata": {
     "codeCollapsed": false,
@@ -120,19 +120,12 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "SnowflakeLoginOptions() is in private preview since 0.2.0. Do not use it in production. \n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<snowflake.snowpark.session.Session at 0x375ac7ee0>"
+       "<snowflake.snowpark.session.Session at 0x321b318b0>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,6 +155,7 @@
     "from snowflake.snowpark.functions import col, to_timestamp, min, max, month, dayofmonth, dayofweek, dayofyear, avg, median, date_add\n",
     "from snowflake.snowpark.types import IntegerType\n",
     "from snowflake.snowpark import Window\n",
+    "from snowflake.snowpark.functions import sql_expr\n",
     "\n",
     "#setup snowpark session\n",
     "from snowflake.snowpark.context import get_active_session\n",
@@ -170,7 +164,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowflake.snowpark.functions import sql_expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
    "id": "f8900d1d-a1f2-419b-ae7e-b194f268d904",
    "metadata": {
     "codeCollapsed": false,
@@ -224,26 +227,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "369245"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.count()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 8,
    "id": "a6654de7-6407-4ffe-a214-fd66078397ef",
    "metadata": {
@@ -273,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -282,7 +265,7 @@
        "datetime.datetime(2024, 11, 28, 7, 40, 13, 440000)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,16 +280,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "datetime.timedelta(days=109, seconds=30598, microseconds=770251)"
+       "datetime.timedelta(days=110, seconds=11854, microseconds=176584)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,14 +324,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "id": "4b5a38cc-c479-4839-b0ae-9e5cb3e0facb",
    "metadata": {
     "codeCollapsed": false,
     "language": "python",
     "name": "find_timedelta"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<snowflake.snowpark.dataframe.DataFrame at 0x1753abc70>"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#Get current date and time\n",
     "current_time = datetime.now()\n",
@@ -375,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,14 +409,16 @@
     "    )\n",
     "    \n",
     "    # Step 5: Time-based rolling average\n",
-    "    df = df.analytics.time_series_agg(\n",
-    "        aggs={\"LOAN_AMOUNT\": [\"AVG\"]},\n",
-    "        windows=[\"-30D\"],\n",
-    "        sliding_interval=\"1D\",\n",
-    "        time_col=\"TIMESTAMP\",\n",
-    "        group_by=[\"COUNTY_NAME\"] \n",
+    "    df = df.with_column(\n",
+    "        \"AVG_THIRTY_DAY_LOAN_AMOUNT\",\n",
+    "        sql_expr(\"\"\"\n",
+    "            AVG(LOAN_AMOUNT) OVER (\n",
+    "                PARTITION BY COUNTY_NAME \n",
+    "                ORDER BY TIMESTAMP \n",
+    "                RANGE BETWEEN INTERVAL '30 DAYS' PRECEDING AND CURRENT ROW\n",
+    "            )\n",
+    "        \"\"\")\n",
     "    )\n",
-    "    df = df.rename(\"LOAN_AMOUNT_AVG_-30D\", \"AVG_THIRTY_DAY_LOAN_AMOUNT\")\n",
     "\n",
     "    return df\n",
     "    \n",
@@ -434,6 +430,47 @@
     "         \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \n",
     "         \"AVG_THIRTY_DAY_LOAN_AMOUNT\"]\n",
     "    )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|\"LOAN_ID\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"AVG_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|420583     |2024-04-19 23:11:54.240000  |4        |110            |5       |108000         |73000.0   |0.6759259259259259   |65260.797342192694   |1                   |108000.000                    |\n",
+      "|398637     |2024-04-20 12:53:34.080000  |4        |111            |6       |60000          |NULL      |NULL                 |65260.797342192694   |NULL                |84000.000                     |\n",
+      "|451518     |2024-04-20 13:32:26.880000  |4        |111            |6       |63000          |NULL      |NULL                 |65260.797342192694   |NULL                |77000.000                     |\n",
+      "|277487     |2024-04-20 15:10:56.640000  |4        |111            |6       |110000         |110000.0  |1.0                  |65260.797342192694   |1                   |85250.000                     |\n",
+      "|412052     |2024-04-21 02:15:47.520000  |4        |112            |0       |117000         |NULL      |NULL                 |65260.797342192694   |NULL                |91600.000                     |\n",
+      "|114863     |2024-04-21 02:23:34.080000  |4        |112            |0       |79000          |38000.0   |0.4810126582278481   |65260.797342192694   |0                   |89500.000                     |\n",
+      "|258183     |2024-04-21 07:59:13.920000  |4        |112            |0       |152000         |74000.0   |0.4868421052631579   |65260.797342192694   |1                   |98428.571                     |\n",
+      "|436627     |2024-04-21 19:10:33.600000  |4        |112            |0       |80000          |NULL      |NULL                 |65260.797342192694   |NULL                |96125.000                     |\n",
+      "|196089     |2024-04-21 20:30:54.720000  |4        |112            |0       |6000           |25000.0   |4.166666666666667    |65260.797342192694   |0                   |86111.111                     |\n",
+      "|271388     |2024-04-21 23:46:36.480000  |4        |112            |0       |174000         |68000.0   |0.39080459770114945  |65260.797342192694   |1                   |94900.000                     |\n",
+      "|238086     |2024-04-22 19:19:29.280000  |4        |113            |1       |60000          |49000.0   |0.8166666666666667   |65260.797342192694   |0                   |91727.272                     |\n",
+      "|251670     |2024-04-22 21:39:27.360000  |4        |113            |1       |35000          |51000.0   |1.457142857142857    |65260.797342192694   |0                   |87000.000                     |\n",
+      "|316384     |2024-04-23 00:38:18.240000  |4        |114            |2       |129000         |33000.0   |0.2558139534883721   |65260.797342192694   |0                   |90230.769                     |\n",
+      "|413560     |2024-04-23 04:17:19.680000  |4        |114            |2       |127000         |37000.0   |0.29133858267716534  |65260.797342192694   |0                   |92857.142                     |\n",
+      "|233097     |2024-04-23 08:55:58.080000  |4        |114            |2       |76000          |NULL      |NULL                 |65260.797342192694   |NULL                |91733.333                     |\n",
+      "|403478     |2024-04-23 11:48:20.160000  |4        |114            |2       |119000         |67000.0   |0.5630252100840336   |65260.797342192694   |1                   |93437.500                     |\n",
+      "|286594     |2024-04-23 12:10:22.080000  |4        |114            |2       |108000         |63000.0   |0.5833333333333334   |65260.797342192694   |0                   |94294.117                     |\n",
+      "|113243     |2024-04-23 12:18:08.640000  |4        |114            |2       |134000         |106000.0  |0.7910447761194029   |65260.797342192694   |1                   |96500.000                     |\n",
+      "|112944     |2024-04-23 14:57:33.120000  |4        |114            |2       |20000          |77000.0   |3.85                 |65260.797342192694   |1                   |92473.684                     |\n",
+      "|170703     |2024-04-23 21:25:03.360000  |4        |114            |2       |84000          |36000.0   |0.42857142857142855  |65260.797342192694   |0                   |92050.000                     |\n",
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "feature_df.show(20)"
    ]
   },
   {
@@ -479,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 80,
    "id": "b6c4ead8-25ac-46cc-9bd9-17eac2f796d5",
    "metadata": {
     "codeCollapsed": false,
@@ -496,59 +533,26 @@
       "---------DATAFRAME EXECUTION PLAN----------\n",
       "Query List:\n",
       "1.\n",
-      "SELECT \"LOAN_ID\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \"LOAN_AMOUNT_AVG_-30D\" AS \"AVG_THIRTY_DAY_LOAN_AMOUNT\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"LOAN_AMOUNT_AVG_-30D\" AS \"LOAN_AMOUNT_AVG_-30D\" FROM ( SELECT \"COUNTY_NAME\", \"TIMESTAMP\", AVG(\"LOAN_AMOUNTB\") AS \"LOAN_AMOUNT_AVG_-30D\" FROM ( SELECT  *  FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\", AVG(\"LOAN_AMOUNT\") AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME)))) GROUP BY \"COUNTY_NAME\", \"SLIDING_POINT\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, sliding_point)))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINTB\" AS \"SLIDING_POINTB\", \"LOAN_IDB\" AS \"LOAN_IDB\", \"TSB\" AS \"TSB\", \"LOAN_TYPE_NAMEB\" AS \"LOAN_TYPE_NAMEB\", \"LOAN_PURPOSE_NAMEB\" AS \"LOAN_PURPOSE_NAMEB\", \"APPLICANT_INCOME_000SB\" AS \"APPLICANT_INCOME_000SB\", \"LOAN_AMOUNT_000SB\" AS \"LOAN_AMOUNT_000SB\", \"MORTGAGERESPONSEB\" AS \"MORTGAGERESPONSEB\", \"TIMESTAMPB\" AS \"TIMESTAMPB\", \"MONTHB\" AS \"MONTHB\", \"DAY_OF_YEARB\" AS \"DAY_OF_YEARB\", \"DOTWB\" AS \"DOTWB\", \"LOAN_AMOUNTB\" AS \"LOAN_AMOUNTB\", \"INCOMEB\" AS \"INCOMEB\", \"INCOME_LOAN_RATIOB\" AS \"INCOME_LOAN_RATIOB\", \"AVG_COUNTY_INCOMEB\" AS \"AVG_COUNTY_INCOMEB\", \"HIGH_INCOME_FLAGB\" AS \"HIGH_INCOME_FLAGB\", \"LOAN_AMOUNT_AVGB\" AS \"LOAN_AMOUNT_AVGB\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINTB\", \"LOAN_ID\" AS \"LOAN_IDB\", \"TS\" AS \"TSB\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAMEB\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAMEB\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000SB\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000SB\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSEB\", \"TIMESTAMP\" AS \"TIMESTAMPB\", \"MONTH\" AS \"MONTHB\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEARB\", \"DOTW\" AS \"DOTWB\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNTB\", \"INCOME\" AS \"INCOMEB\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIOB\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOMEB\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAGB\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVGB\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\", AVG(\"LOAN_AMOUNT\") AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME)))) GROUP BY \"COUNTY_NAME\", \"SLIDING_POINT\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, sliding_point))))) AS SNOWPARK_RIGHT USING (COUNTY_NAME))) WHERE ((\"SLIDING_POINTB\" >= dateadd('d', -30, \"SLIDING_POINT\")) AND (\"SLIDING_POINTB\" <= \"SLIDING_POINT\"))) GROUP BY \"COUNTY_NAME\", \"TIMESTAMP\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, TIMESTAMP)))\n",
+      "SELECT \"LOAN_ID\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \"AVG_THIRTY_DAY_LOAN_AMOUNT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \n",
+      "            AVG(LOAN_AMOUNT) OVER (\n",
+      "                PARTITION BY COUNTY_NAME \n",
+      "                ORDER BY TIMESTAMP \n",
+      "                RANGE BETWEEN INTERVAL '30 DAYS' PRECEDING AND CURRENT ROW\n",
+      "            )\n",
+      "         AS \"AVG_THIRTY_DAY_LOAN_AMOUNT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 109, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 109, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 109, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 109, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME)))))\n",
       "Logical Execution Plan:\n",
       "GlobalStats:\n",
-      "    partitionsTotal=6\n",
-      "    partitionsAssigned=6\n",
-      "    bytesAssigned=27709440\n",
+      "    partitionsTotal=2\n",
+      "    partitionsAssigned=2\n",
+      "    bytesAssigned=9236480\n",
       "Operations:\n",
-      "1:0     ->Result  MORTGAGE_LENDING_DEMO_DATA.LOAN_ID, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)), EXTRACT(month from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofyear from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofweek from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000, MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0, (MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) / (TO_DOUBLE(MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000)), (SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))), BOOLEAN_TO_NUMBER((MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) > ((SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))))), SNOWPARK_RIGHT.\"LOAN_AMOUNT_AVG_-30D\"  \n",
-      "1:1          ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:4               ->Aggregate  aggExprs: [SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0), COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
-      "1:5                    ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  APPLICANT_INCOME_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
-      "1:6               ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.TIMESTAMP = DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))  \n",
-      "1:7                    ->Aggregate  aggExprs: [SUM(SUM_INTERNAL(SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*))), COUNT(COUNT_INTERNAL(COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*)))], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))]  \n",
-      "1:8                         ->Aggregate  aggExprs: [SUM_INTERNAL(SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*)), COUNT_INTERNAL(COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*))], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))]  \n",
-      "1:9                              ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = SNOWPARK_RIGHT.COUNTY_NAME), joinFilter: ((SNOWPARK_RIGHT.SLIDING_POINTB) >= (DATE_ADDDAYSTOTIMESTAMP(-30, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)))) AND (SNOWPARK_RIGHT.SLIDING_POINTB <= (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)))  \n",
-      "1:10                                   ->Aggregate  aggExprs: [COUNT(*)], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)), TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:11                                        ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:12                                             ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:13                                                  ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:15                                             ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.SLIDING_POINT = TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400))  \n",
-      "1:16                                                  ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:17                                                       ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:18                                                            ->SemiJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:19                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
-      "1:20                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:21                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:23                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:24                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:25                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:26                                                                                ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
-      "1:27                                                  ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:28                                                       ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:29                                                            ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
-      "1:30                                   ->Aggregate  aggExprs: [SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB)], groupKeys: [SNOWPARK_RIGHT.COUNTY_NAME, SNOWPARK_RIGHT.SLIDING_POINTB]  \n",
-      "1:31                                        ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:32                                             ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:33                                                  ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:35                                             ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.SLIDING_POINT = TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400))  \n",
-      "1:36                                                  ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:37                                                       ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:38                                                            ->SemiJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:39                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
-      "1:40                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:41                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:43                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
-      "1:44                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:45                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:46                                                                                ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
-      "1:47                                                  ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
-      "1:48                                                       ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:49                                                            ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, LOAN_AMOUNT_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
-      "1:50                    ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
-      "1:51                         ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  LOAN_ID, TS, APPLICANT_INCOME_000S, LOAN_AMOUNT_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:0     ->Result  MORTGAGE_LENDING_DEMO_DATA.LOAN_ID, DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)), EXTRACT(month from DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofyear from DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofweek from DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000, MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0, (MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) / (TO_DOUBLE(MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000)), (SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))), BOOLEAN_TO_NUMBER((MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) > ((SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))))), AVG(MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000) OVER (PARTITION BY MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME ORDER BY DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)) ASC NULLS LAST)  \n",
+      "1:1          ->WindowFunction  AVG(MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000) OVER (PARTITION BY MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME ORDER BY DATE_ADDDAYSTOTIMESTAMP(109, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)) ASC NULLS LAST)  \n",
+      "1:2               ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:3                    ->Aggregate  aggExprs: [SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0), COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
+      "1:4                         ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  APPLICANT_INCOME_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:5                    ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:6                         ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  LOAN_ID, TS, APPLICANT_INCOME_000S, LOAN_AMOUNT_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
       "\n",
       "--------------------------------------------\n",
       "None\n"
@@ -572,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 81,
    "id": "abacdc71-9f2c-419f-8d50-3e8f89be367f",
    "metadata": {
     "codeCollapsed": false,
@@ -594,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 82,
    "id": "67480d6a-183f-4373-aaa8-d3ed8e80e11d",
    "metadata": {
     "codeCollapsed": false,
@@ -607,10 +611,10 @@
     {
      "data": {
       "text/plain": [
-       "<snowflake.snowpark.dataframe.DataFrame at 0x3200aa370>"
+       "<snowflake.snowpark.dataframe.DataFrame at 0x321f00340>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 83,
    "id": "e91d6d39-7819-4825-8729-a3f19ca5cdf7",
    "metadata": {
     "codeCollapsed": false,
@@ -647,7 +651,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Registered new entity\n"
+      "Retrieved existing entity\n"
      ]
     }
    ],
@@ -683,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 86,
    "id": "2b53364f-90c4-45b4-94ee-b2fde6f93475",
    "metadata": {
     "codeCollapsed": false,
@@ -719,7 +723,7 @@
     "    }\n",
     ")\n",
     "\n",
-    "loan_fv = fs.register_feature_view(loan_fv, version=VERSION_NUM, overwrite=True)"
+    "loan_fv = fs.register_feature_view(loan_fv, version=\"7\", overwrite=True)"
    ]
   },
   {

--- a/train_deploy_monitor_ML_in_snowflake.ipynb
+++ b/train_deploy_monitor_ML_in_snowflake.ipynb
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 58,
    "id": "d78265b8-8baa-4136-a32a-32f3f620949d",
    "metadata": {
     "codeCollapsed": false,
@@ -165,15 +165,12 @@
     "\n",
     "#setup snowpark session\n",
     "from snowflake.snowpark.context import get_active_session\n",
-    "from snowflake.snowpark.session import Session\n",
-    "from snowflake.ml.utils.connection_params import SnowflakeLoginOptions\n",
-    "session = Session.builder.configs(SnowflakeLoginOptions()).create()\n",
     "session"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 51,
    "id": "f8900d1d-a1f2-419b-ae7e-b194f268d904",
    "metadata": {
     "codeCollapsed": false,
@@ -378,63 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "b355c0c4-9dc6-4faf-86b7-24d8d559e453",
-   "metadata": {
-    "codeCollapsed": false,
-    "collapsed": false,
-    "language": "python",
-    "name": "define_features",
-    "resultHeight": 0
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "|\"LOAN_ID\"  |\"TS\"                     |\"LOAN_TYPE_NAME\"  |\"LOAN_PURPOSE_NAME\"  |\"APPLICANT_INCOME_000S\"  |\"LOAN_AMOUNT_000S\"  |\"COUNTY_NAME\"  |\"MORTGAGERESPONSE\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"MEDIAN_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
-      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "|329572     |2024-09-15 13:44:41.280  |Conventional      |Refinancing          |NULL                     |68                  |Kings County   |0                   |2025-01-01 13:44:41.280000  |1        |1              |3       |68000          |NULL      |NULL                 |111000.0                |NULL                |68000.000                     |\n",
-      "|266349     |2024-09-15 10:56:12.480  |Conventional      |Refinancing          |NULL                     |190                 |Ulster County  |1                   |2025-01-01 10:56:12.480000  |1        |1              |3       |190000         |NULL      |NULL                 |79000.0                 |NULL                |129000.000                    |\n",
-      "|220929     |2024-09-15 11:54:31.680  |Conventional      |Home purchase        |60.0                     |137                 |Albany County  |1                   |2025-01-01 11:54:31.680000  |1        |1              |3       |137000         |60000.0   |0.43795620437956206  |79000.0                 |0                   |131666.666                    |\n",
-      "------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "#Create a dict with keys for feature names and values containing transform code\n",
-    "\n",
-    "feature_eng_dict = dict()\n",
-    "\n",
-    "#Timstamp features\n",
-    "feature_eng_dict[\"TIMESTAMP\"] = date_add(to_timestamp(\"TS\"), timedelta.days-1)\n",
-    "feature_eng_dict[\"MONTH\"] = month(\"TIMESTAMP\")\n",
-    "feature_eng_dict[\"DAY_OF_YEAR\"] = dayofyear(\"TIMESTAMP\") \n",
-    "feature_eng_dict[\"DOTW\"] = dayofweek(\"TIMESTAMP\")\n",
-    "\n",
-    "# df= df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\n",
-    "\n",
-    "#Income and loan features\n",
-    "feature_eng_dict[\"LOAN_AMOUNT\"] = col(\"LOAN_AMOUNT_000s\")*1000\n",
-    "feature_eng_dict[\"INCOME\"] = col(\"APPLICANT_INCOME_000s\")*1000\n",
-    "feature_eng_dict[\"INCOME_LOAN_RATIO\"] = col(\"INCOME\")/col(\"LOAN_AMOUNT\")\n",
-    "\n",
-    "county_window_spec = Window.partition_by(\"COUNTY_NAME\")\n",
-    "feature_eng_dict[\"MEDIAN_COUNTY_INCOME\"] = median(\"INCOME\").over(county_window_spec)\n",
-    "feature_eng_dict[\"HIGH_INCOME_FLAG\"] = (col(\"INCOME\")>col(\"MEDIAN_COUNTY_INCOME\")).astype(IntegerType())\n",
-    "\n",
-    "day_window_spec = Window.order_by(\"DAY_OF_YEAR\").rows_between(-30,0)\n",
-    "feature_eng_dict[\"AVG_THIRTY_DAY_LOAN_AMOUNT\"] =  avg(\"LOAN_AMOUNT\").over(day_window_spec)\n",
-    "\n",
-    "df = df.with_columns(feature_eng_dict.keys(), feature_eng_dict.values())\n",
-    "df.show(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +403,7 @@
     "    \n",
     "    # Step 3: County-level income stats (Per-group features)\n",
     "    county_income_df = df.group_by([\"COUNTY_NAME\"]).agg(\n",
-    "        median(\"INCOME\").alias(\"MEDIAN_COUNTY_INCOME\")\n",
+    "        avg(\"INCOME\").alias(\"AVG_COUNTY_INCOME\")\n",
     "    )\n",
     "    # Join back to the original dataframe\n",
     "    df = df.join(county_income_df, \"COUNTY_NAME\")\n",
@@ -470,7 +411,7 @@
     "    # Step 4: Add high income flag\n",
     "    df = df.with_column(\n",
     "        \"HIGH_INCOME_FLAG\", \n",
-    "        (col(\"INCOME\") > col(\"MEDIAN_COUNTY_INCOME\")).astype(IntegerType())\n",
+    "        (col(\"INCOME\") > col(\"AVG_COUNTY_INCOME\")).astype(IntegerType())\n",
     "    )\n",
     "    \n",
     "    # Step 5: Time-based rolling average\n",
@@ -483,72 +424,62 @@
     "    )\n",
     "    df = df.rename(\"LOAN_AMOUNT_AVG_-30D\", \"AVG_THIRTY_DAY_LOAN_AMOUNT\")\n",
     "\n",
-    "    # Step 6: Select only ID, timestamp, and engineered features\n",
-    "    feature_df = df.select(\n",
+    "    return df\n",
+    "    \n",
+    "df = create_mortgage_features(df)\n",
+    "\n",
+    "feature_df = df.select(\n",
     "        [\"LOAN_ID\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \n",
     "         \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \n",
-    "         \"MEDIAN_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \n",
+    "         \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \n",
     "         \"AVG_THIRTY_DAY_LOAN_AMOUNT\"]\n",
-    "    )\n",
-    "    \n",
-    "    return feature_df\n",
-    "\n",
-    "feature_df = create_mortgage_features(df)"
+    "    )\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "feature_df.count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "|\"LOAN_ID\"  |\"TS\"                     |\"LOAN_TYPE_NAME\"    |\"LOAN_PURPOSE_NAME\"  |\"APPLICANT_INCOME_000S\"  |\"LOAN_AMOUNT_000S\"  |\"COUNTY_NAME\"       |\"MORTGAGERESPONSE\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"MEDIAN_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
-      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "|329572     |2024-09-15 13:44:41.280  |Conventional        |Refinancing          |NULL                     |68                  |Kings County        |0                   |2025-01-01 13:44:41.280000  |1        |1              |3       |68000          |NULL      |NULL                 |111000.0                |NULL                |68000.000                     |\n",
-      "|266349     |2024-09-15 10:56:12.480  |Conventional        |Refinancing          |NULL                     |190                 |Ulster County       |1                   |2025-01-01 10:56:12.480000  |1        |1              |3       |190000         |NULL      |NULL                 |79000.0                 |NULL                |129000.000                    |\n",
-      "|220929     |2024-09-15 11:54:31.680  |Conventional        |Home purchase        |60.0                     |137                 |Albany County       |1                   |2025-01-01 11:54:31.680000  |1        |1              |3       |137000         |60000.0   |0.43795620437956206  |79000.0                 |0                   |131666.666                    |\n",
-      "|452183     |2024-09-15 20:57:33.120  |FHA-insured         |Refinancing          |66.0                     |303                 |Nassau County       |1                   |2025-01-01 20:57:33.120000  |1        |1              |3       |303000         |66000.0   |0.21782178217821782  |119000.0                |0                   |174500.000                    |\n",
-      "|201235     |2024-09-15 01:18:11.520  |Conventional        |Home purchase        |83.0                     |131                 |Ulster County       |1                   |2025-01-01 01:18:11.520000  |1        |1              |3       |131000         |83000.0   |0.6335877862595419   |79000.0                 |1                   |165800.000                    |\n",
-      "|428244     |2024-09-15 05:12:46.080  |Conventional        |Refinancing          |NULL                     |1158                |Kings County        |1                   |2025-01-01 05:12:46.080000  |1        |1              |3       |1158000        |NULL      |NULL                 |111000.0                |NULL                |331166.666                    |\n",
-      "|112782     |2024-09-15 21:04:01.920  |Conventional        |Refinancing          |55.0                     |90                  |Broome County       |1                   |2025-01-01 21:04:01.920000  |1        |1              |3       |90000          |55000.0   |0.6111111111111112   |59000.0                 |0                   |296714.285                    |\n",
-      "|136738     |2024-09-15 13:14:52.800  |Conventional        |Home purchase        |115.0                    |184                 |Bronx County        |1                   |2025-01-01 13:14:52.800000  |1        |1              |3       |184000         |115000.0  |0.625                |87000.0                 |1                   |282625.000                    |\n",
-      "|324015     |2024-09-15 03:09:38.880  |Conventional        |Home purchase        |121.0                    |100                 |Nassau County       |1                   |2025-01-01 03:09:38.880000  |1        |1              |3       |100000         |121000.0  |1.21                 |119000.0                |1                   |262333.333                    |\n",
-      "|132297     |2024-09-15 20:10:53.760  |Conventional        |Refinancing          |112.0                    |116                 |Suffolk County      |1                   |2025-01-01 20:10:53.760000  |1        |1              |3       |116000         |112000.0  |0.9655172413793104   |106000.0                |1                   |247700.000                    |\n",
-      "|109620     |2024-09-15 13:03:12.960  |FHA-insured         |Home purchase        |51.0                     |101                 |Monroe County       |1                   |2025-01-01 13:03:12.960000  |1        |1              |3       |101000         |51000.0   |0.504950495049505    |64000.0                 |0                   |234363.636                    |\n",
-      "|450041     |2024-09-15 03:31:40.800  |FHA-insured         |Home purchase        |NULL                     |33                  |Cattaraugus County  |1                   |2025-01-01 03:31:40.800000  |1        |1              |3       |33000          |NULL      |NULL                 |52000.0                 |NULL                |217583.333                    |\n",
-      "|299797     |2024-09-15 15:02:26.880  |Conventional        |Refinancing          |161.0                    |383                 |Suffolk County      |1                   |2025-01-01 15:02:26.880000  |1        |1              |3       |383000         |161000.0  |0.42036553524804177  |106000.0                |1                   |230307.692                    |\n",
-      "|407708     |2024-09-15 00:23:45.600  |Conventional        |Home improvement     |23.0                     |16                  |Nassau County       |0                   |2025-01-01 00:23:45.600000  |1        |1              |3       |16000          |23000.0   |1.4375               |119000.0                |0                   |215000.000                    |\n",
-      "|327330     |2024-09-15 14:36:31.680  |Conventional        |Home purchase        |NULL                     |850                 |New York County     |0                   |2025-01-01 14:36:31.680000  |1        |1              |3       |850000         |NULL      |NULL                 |228000.0                |NULL                |257333.333                    |\n",
-      "|220149     |2024-09-15 20:07:00.480  |Conventional        |Home improvement     |82.0                     |31                  |Erie County         |1                   |2025-01-01 20:07:00.480000  |1        |1              |3       |31000          |82000.0   |2.6451612903225805   |64000.0                 |1                   |243187.500                    |\n",
-      "|261060     |2024-09-15 09:35:51.360  |VA-guaranteed       |Home purchase        |77.0                     |148                 |Essex County        |1                   |2025-01-01 09:35:51.360000  |1        |1              |3       |148000         |77000.0   |0.5202702702702703   |68000.0                 |1                   |237588.235                    |\n",
-      "|237371     |2024-09-15 13:30:25.920  |Conventional        |Home purchase        |81.0                     |157                 |Erie County         |1                   |2025-01-01 13:30:25.920000  |1        |1              |3       |157000         |81000.0   |0.5159235668789809   |64000.0                 |1                   |233111.111                    |\n",
-      "|124223     |2024-09-15 11:24:43.200  |FSA/RHS-guaranteed  |Home purchase        |70.0                     |99                  |Wayne County        |1                   |2025-01-01 11:24:43.200000  |1        |1              |3       |99000          |70000.0   |0.7070707070707071   |59000.0                 |1                   |226052.631                    |\n",
-      "|425429     |2024-09-15 15:49:06.240  |Conventional        |Home purchase        |52.0                     |152                 |Nassau County       |1                   |2025-01-01 15:49:06.240000  |1        |1              |3       |152000         |52000.0   |0.34210526315789475  |119000.0                |0                   |222350.000                    |\n",
-      "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|\"LOAN_ID\"  |\"TIMESTAMP\"                 |\"MONTH\"  |\"DAY_OF_YEAR\"  |\"DOTW\"  |\"LOAN_AMOUNT\"  |\"INCOME\"  |\"INCOME_LOAN_RATIO\"  |\"AVG_COUNTY_INCOME\"  |\"HIGH_INCOME_FLAG\"  |\"AVG_THIRTY_DAY_LOAN_AMOUNT\"  |\n",
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
+      "|460124     |2024-09-09 07:20:38.400000  |9        |253            |1       |196000         |NULL      |NULL                 |80864.49659348978    |NULL                |128440.559441                 |\n",
+      "|444931     |2024-12-28 20:43:52.320000  |12       |363            |6       |65000          |22000.0   |0.3384615384615385   |80911.1872857588     |0                   |149172.925359                 |\n",
+      "|456257     |2024-06-29 20:36:23.040000  |6        |181            |6       |147000         |NULL      |NULL                 |80911.1872857588     |NULL                |172854.196643                 |\n",
+      "|313469     |2024-10-16 10:03:47.520000  |10       |290            |3       |90000          |44000.0   |0.4888888888888889   |68702.56776034237    |0                   |83297.124601                  |\n",
+      "|266947     |2024-11-14 14:08:26.880000  |11       |319            |4       |271000         |NULL      |NULL                 |109730.29772329247   |NULL                |199877.470356                 |\n",
+      "|444854     |2025-01-05 07:34:45.120000  |1        |5              |0       |295000         |69000.0   |0.23389830508474577  |168684.74852627618   |0                   |345319.827586                 |\n",
+      "|343353     |2025-02-18 10:02:38.400000  |2        |49             |2       |260000         |42000.0   |0.16153846153846155  |71591.18644067796    |0                   |69684.563758                  |\n",
+      "|416046     |2025-01-23 09:54:43.200000  |1        |23             |4       |282000         |NULL      |NULL                 |108568.8192316757    |NULL                |363738.012509                 |\n",
+      "|382754     |2024-10-26 12:56:00.960000  |10       |300            |6       |364000         |NULL      |NULL                 |100784.93335330237   |NULL                |476545.667447                 |\n",
+      "|312341     |2025-01-18 02:29:36.960000  |1        |18             |6       |335000         |338000.0  |1.008955223880597    |80911.1872857588     |1                   |153022.570244                 |\n",
+      "|199634     |2024-06-21 21:55:17.760000  |6        |173            |5       |289000         |102000.0  |0.35294117647058826  |193289.20698539936   |0                   |400460.242233                 |\n",
+      "|191143     |2024-06-01 04:31:00.480000  |6        |153            |6       |117000         |NULL      |NULL                 |83856.4406008193     |NULL                |135660.457240                 |\n",
+      "|197256     |2024-06-10 06:13:23.520000  |6        |162            |1       |58000          |47000.0   |0.8103448275862069   |72556.85240963855    |0                   |76837.638376                  |\n",
+      "|253680     |2025-01-16 13:42:31.680000  |1        |16             |4       |433000         |180000.0  |0.41570438799076215  |96964.77322765302    |1                   |192505.376344                 |\n",
+      "|406177     |2024-10-03 22:23:05.280000  |10       |277            |4       |724000         |819000.0  |1.1312154696132597   |412055.8472278313    |1                   |1215629.532317                |\n",
+      "|190428     |2024-11-10 12:53:51.360000  |11       |315            |0       |200000         |104000.0  |0.52                 |100784.93335330237   |1                   |446571.264368                 |\n",
+      "|287280     |2025-03-02 21:48:31.680000  |3        |61             |0       |617000         |185000.0  |0.29983792544570503  |164794.20667815395   |1                   |667661.718750                 |\n",
+      "|153770     |2024-05-15 22:43:23.520000  |5        |136            |3       |225000         |108000.0  |0.48                 |74447.4858673014     |1                   |110876.506024                 |\n",
+      "|420366     |2024-05-29 12:52:59.520000  |5        |150            |3       |240000         |NULL      |NULL                 |96964.77322765302    |NULL                |180044.776119                 |\n",
+      "|355768     |2025-02-18 07:56:55.680000  |2        |49             |2       |15000          |31000.0   |2.066666666666667    |82967.60555647065    |0                   |119181.038830                 |\n",
+      "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df.show(20)"
+    "feature_df.show(20)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 54,
    "id": "b6c4ead8-25ac-46cc-9bd9-17eac2f796d5",
    "metadata": {
     "codeCollapsed": false,
@@ -565,15 +496,59 @@
       "---------DATAFRAME EXECUTION PLAN----------\n",
       "Query List:\n",
       "1.\n",
-      "SELECT  *  FROM MORTGAGE_LENDING_DEMO_DATA\n",
+      "SELECT \"LOAN_ID\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\", \"LOAN_AMOUNT_AVG_-30D\" AS \"AVG_THIRTY_DAY_LOAN_AMOUNT\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"LOAN_AMOUNT_AVG_-30D\" AS \"LOAN_AMOUNT_AVG_-30D\" FROM ( SELECT \"COUNTY_NAME\", \"TIMESTAMP\", AVG(\"LOAN_AMOUNTB\") AS \"LOAN_AMOUNT_AVG_-30D\" FROM ( SELECT  *  FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\", AVG(\"LOAN_AMOUNT\") AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME)))) GROUP BY \"COUNTY_NAME\", \"SLIDING_POINT\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, sliding_point)))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINTB\" AS \"SLIDING_POINTB\", \"LOAN_IDB\" AS \"LOAN_IDB\", \"TSB\" AS \"TSB\", \"LOAN_TYPE_NAMEB\" AS \"LOAN_TYPE_NAMEB\", \"LOAN_PURPOSE_NAMEB\" AS \"LOAN_PURPOSE_NAMEB\", \"APPLICANT_INCOME_000SB\" AS \"APPLICANT_INCOME_000SB\", \"LOAN_AMOUNT_000SB\" AS \"LOAN_AMOUNT_000SB\", \"MORTGAGERESPONSEB\" AS \"MORTGAGERESPONSEB\", \"TIMESTAMPB\" AS \"TIMESTAMPB\", \"MONTHB\" AS \"MONTHB\", \"DAY_OF_YEARB\" AS \"DAY_OF_YEARB\", \"DOTWB\" AS \"DOTWB\", \"LOAN_AMOUNTB\" AS \"LOAN_AMOUNTB\", \"INCOMEB\" AS \"INCOMEB\", \"INCOME_LOAN_RATIOB\" AS \"INCOME_LOAN_RATIOB\", \"AVG_COUNTY_INCOMEB\" AS \"AVG_COUNTY_INCOMEB\", \"HIGH_INCOME_FLAGB\" AS \"HIGH_INCOME_FLAGB\", \"LOAN_AMOUNT_AVGB\" AS \"LOAN_AMOUNT_AVGB\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINTB\", \"LOAN_ID\" AS \"LOAN_IDB\", \"TS\" AS \"TSB\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAMEB\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAMEB\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000SB\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000SB\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSEB\", \"TIMESTAMP\" AS \"TIMESTAMPB\", \"MONTH\" AS \"MONTHB\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEARB\", \"DOTW\" AS \"DOTWB\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNTB\", \"INCOME\" AS \"INCOMEB\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIOB\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOMEB\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAGB\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVGB\" FROM ( SELECT  *  FROM (( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\", \"HIGH_INCOME_FLAG\" AS \"HIGH_INCOME_FLAG\", \"SLIDING_POINT\" AS \"SLIDING_POINT\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME))))) AS SNOWPARK_LEFT LEFT OUTER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"SLIDING_POINT\" AS \"SLIDING_POINT\", \"LOAN_AMOUNT_AVG\" AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"SLIDING_POINT\", AVG(\"LOAN_AMOUNT\") AS \"LOAN_AMOUNT_AVG\" FROM ( SELECT \"COUNTY_NAME\", \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", \"LOAN_AMOUNT\", \"INCOME\", \"INCOME_LOAN_RATIO\", \"AVG_COUNTY_INCOME\",  CAST ((\"INCOME\" > \"AVG_COUNTY_INCOME\") AS INT) AS \"HIGH_INCOME_FLAG\", to_timestamp(( CAST ((date_part('epoch_second', to_timestamp(\"TIMESTAMP\")) / 86400) AS BIGINT) * 86400)) AS \"SLIDING_POINT\" FROM ( SELECT  *  FROM (( SELECT \"LOAN_ID\" AS \"LOAN_ID\", \"TS\" AS \"TS\", \"LOAN_TYPE_NAME\" AS \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\" AS \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\" AS \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\" AS \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"MORTGAGERESPONSE\" AS \"MORTGAGERESPONSE\", \"TIMESTAMP\" AS \"TIMESTAMP\", \"MONTH\" AS \"MONTH\", \"DAY_OF_YEAR\" AS \"DAY_OF_YEAR\", \"DOTW\" AS \"DOTW\", \"LOAN_AMOUNT\" AS \"LOAN_AMOUNT\", \"INCOME\" AS \"INCOME\", \"INCOME_LOAN_RATIO\" AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA))) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"COUNTY_NAME\" AS \"COUNTY_NAME\", \"AVG_COUNTY_INCOME\" AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"COUNTY_NAME\", avg(\"INCOME\") AS \"AVG_COUNTY_INCOME\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", \"TIMESTAMP\", \"MONTH\", \"DAY_OF_YEAR\", \"DOTW\", (\"LOAN_AMOUNT_000S\" * 1000) AS \"LOAN_AMOUNT\", (\"APPLICANT_INCOME_000S\" * 1000) AS \"INCOME\", (\"INCOME\" / \"LOAN_AMOUNT\") AS \"INCOME_LOAN_RATIO\" FROM ( SELECT \"LOAN_ID\", \"TS\", \"LOAN_TYPE_NAME\", \"LOAN_PURPOSE_NAME\", \"APPLICANT_INCOME_000S\", \"LOAN_AMOUNT_000S\", \"COUNTY_NAME\", \"MORTGAGERESPONSE\", dateadd('day', 108, to_timestamp(\"TS\")) AS \"TIMESTAMP\", month(\"TIMESTAMP\") AS \"MONTH\", dayofyear(\"TIMESTAMP\") AS \"DAY_OF_YEAR\", dayofweek(\"TIMESTAMP\") AS \"DOTW\" FROM MORTGAGE_LENDING_DEMO_DATA)) GROUP BY \"COUNTY_NAME\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME)))) GROUP BY \"COUNTY_NAME\", \"SLIDING_POINT\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, sliding_point))))) AS SNOWPARK_RIGHT USING (COUNTY_NAME))) WHERE ((\"SLIDING_POINTB\" >= dateadd('d', -30, \"SLIDING_POINT\")) AND (\"SLIDING_POINTB\" <= \"SLIDING_POINT\"))) GROUP BY \"COUNTY_NAME\", \"TIMESTAMP\")) AS SNOWPARK_RIGHT USING (COUNTY_NAME, TIMESTAMP)))\n",
       "Logical Execution Plan:\n",
       "GlobalStats:\n",
-      "    partitionsTotal=1\n",
-      "    partitionsAssigned=1\n",
-      "    bytesAssigned=4618240\n",
+      "    partitionsTotal=6\n",
+      "    partitionsAssigned=6\n",
+      "    bytesAssigned=27709440\n",
       "Operations:\n",
-      "1:0     ->Result  MORTGAGE_LENDING_DEMO_DATA.LOAN_ID, MORTGAGE_LENDING_DEMO_DATA.TS, MORTGAGE_LENDING_DEMO_DATA.LOAN_TYPE_NAME, MORTGAGE_LENDING_DEMO_DATA.LOAN_PURPOSE_NAME, MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S, MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S, MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, MORTGAGE_LENDING_DEMO_DATA.MORTGAGERESPONSE  \n",
-      "1:1          ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  LOAN_ID, TS, LOAN_TYPE_NAME, LOAN_PURPOSE_NAME, APPLICANT_INCOME_000S, LOAN_AMOUNT_000S, COUNTY_NAME, MORTGAGERESPONSE  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:0     ->Result  MORTGAGE_LENDING_DEMO_DATA.LOAN_ID, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)), EXTRACT(month from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofyear from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), EXTRACT(dayofweek from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))), MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000, MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0, (MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) / (TO_DOUBLE(MORTGAGE_LENDING_DEMO_DATA.LOAN_AMOUNT_000S * 1000)), (SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))), BOOLEAN_TO_NUMBER((MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0) > ((SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)) / (TO_DOUBLE(COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0))))), SNOWPARK_RIGHT.\"LOAN_AMOUNT_AVG_-30D\"  \n",
+      "1:1          ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:4               ->Aggregate  aggExprs: [SUM(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0), COUNT(MORTGAGE_LENDING_DEMO_DATA.APPLICANT_INCOME_000S * 1000.0)], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
+      "1:5                    ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  APPLICANT_INCOME_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:6               ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.TIMESTAMP = DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))  \n",
+      "1:7                    ->Aggregate  aggExprs: [SUM(SUM_INTERNAL(SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*))), COUNT(COUNT_INTERNAL(COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*)))], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))]  \n",
+      "1:8                         ->Aggregate  aggExprs: [SUM_INTERNAL(SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*)), COUNT_INTERNAL(COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(*))], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS))]  \n",
+      "1:9                              ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = SNOWPARK_RIGHT.COUNTY_NAME), joinFilter: ((SNOWPARK_RIGHT.SLIDING_POINTB) >= (DATE_ADDDAYSTOTIMESTAMP(-30, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)))) AND (SNOWPARK_RIGHT.SLIDING_POINTB <= (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)))  \n",
+      "1:10                                   ->Aggregate  aggExprs: [COUNT(*)], groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)), TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:11                                        ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:12                                             ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:13                                                  ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:15                                             ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.SLIDING_POINT = TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400))  \n",
+      "1:16                                                  ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:17                                                       ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:18                                                            ->SemiJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:19                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
+      "1:20                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:21                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:23                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:24                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:25                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:26                                                                                ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:27                                                  ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:28                                                       ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:29                                                            ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:30                                   ->Aggregate  aggExprs: [SUM(SNOWPARK_RIGHT.LOAN_AMOUNTB), COUNT(SNOWPARK_RIGHT.LOAN_AMOUNTB)], groupKeys: [SNOWPARK_RIGHT.COUNTY_NAME, SNOWPARK_RIGHT.SLIDING_POINTB]  \n",
+      "1:31                                        ->InnerJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:32                                             ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:33                                                  ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:35                                             ->LeftOuterJoin  joinKey: (SNOWPARK_RIGHT.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME) AND (SNOWPARK_RIGHT.SLIDING_POINT = TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400))  \n",
+      "1:36                                                  ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:37                                                       ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:38                                                            ->SemiJoin  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:39                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME]  \n",
+      "1:40                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:41                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:43                                                                 ->Aggregate  groupKeys: [MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME, TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400)]  \n",
+      "1:44                                                                      ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (TO_TIMESTAMP(((EXTRACT(epoch_second from DATE_ADDDAYSTOTIMESTAMP(108, TO_TIMESTAMP_NTZ(MORTGAGE_LENDING_DEMO_DATA.TS)))) / 86400) * 86400) IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:45                                                                           ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:46                                                                                ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:47                                                  ->Filter  (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL) AND (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME IS NOT NULL)  \n",
+      "1:48                                                       ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:49                                                            ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  TS, LOAN_AMOUNT_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
+      "1:50                    ->JoinFilter  joinKey: (MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME = MORTGAGE_LENDING_DEMO_DATA.COUNTY_NAME)  \n",
+      "1:51                         ->TableScan  ML_DATASETS.PUBLIC.MORTGAGE_LENDING_DEMO_DATA  LOAN_ID, TS, APPLICANT_INCOME_000S, LOAN_AMOUNT_000S, COUNTY_NAME  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=4618240}\n",
       "\n",
       "--------------------------------------------\n",
       "None\n"
@@ -581,7 +556,7 @@
     }
    ],
    "source": [
-    "print(df.explain())"
+    "print(feature_df.explain())"
    ]
   },
   {
@@ -694,36 +669,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "2820463f-0ea7-43ea-a500-9b034011887d",
-   "metadata": {
-    "codeCollapsed": false,
-    "collapsed": false,
-    "language": "python",
-    "name": "create_feature_df",
-    "resultHeight": 217
-   },
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'NoneType' object has no attribute 'show'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[32], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m#Create a dataframe with just the ID, timestamp, and engineered features. We will use this to define our feature view\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m#feature_df = df.select([\"LOAN_ID\"]+list(feature_eng_dict.keys()))\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[43mfeature_df\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshow\u001b[49m(\u001b[38;5;241m5\u001b[39m)\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'show'"
-     ]
-    }
-   ],
-   "source": [
-    "#Create a dataframe with just the ID, timestamp, and engineered features. We will use this to define our feature view\n",
-    "#feature_df = df.select([\"LOAN_ID\"]+list(feature_eng_dict.keys()))\n",
-    "feature_df.show(5)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "5cf84fe3-4120-4092-b43d-8873da57d461",
    "metadata": {
@@ -738,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "id": "2b53364f-90c4-45b4-94ee-b2fde6f93475",
    "metadata": {
     "codeCollapsed": false,
@@ -755,6 +700,7 @@
     "    entities=[loan_id_entity],\n",
     "    feature_df=feature_df,\n",
     "    timestamp_col=\"TIMESTAMP\",\n",
+    "    refresh_mode=\"INCREMENTAL\",\n",
     "    refresh_freq=\"1 day\")\n",
     "\n",
     "#add feature level descriptions\n",
@@ -767,7 +713,7 @@
     "        \"LOAN_AMOUNT\": \"Loan amount in $USD\",\n",
     "        \"INCOME\": \"Household income in $USD\",\n",
     "        \"INCOME_LOAN_RATIO\": \"Ratio of LOAN_AMOUNT/INCOME\",\n",
-    "        \"MEDIAN_COUNTY_INCOME\": \"Median household income aggregated at county level\",\n",
+    "        \"AVG_COUNTY_INCOME\": \"Average household income aggregated at county level\",\n",
     "        \"HIGH_INCOME_FLAG\": \"Binary flag to indicate whether household income is higher than MEDIAN_COUNTY_INCOME\",\n",
     "        \"AVG_THIRTY_DAY_LOAN_AMOUNT\": \"Rolling 30 day average of LOAN_AMOUNT\"\n",
     "    }\n",


### PR DESCRIPTION
AVG_THIRTY_DAY_LOAN_AMOUNT :
I switched the the code to use  snowpark functions for timeseries aggregation. This will give you more accurate time windows. Existing query was assuming last 30 rows are from last 30 days.
Now time windows are formed within COUNTY data. Previously it was calculating the avg across counties.
MEDIAN_COUNTY_INCOME:
I have switched this to AVG_COUNTY_INCOME. Dynamic table does support incremental refreshes for MEDIAN operation.
Instead of calculating this per row using partition window. I calculate this once using group by and join it back to source.
FV creation:
I explicitly mention the fv to be incremental. (FYI this step takes few minutes).